### PR TITLE
Set higher target, limit lib, use --module node16.

### DIFF
--- a/examples/calendar/src/tsconfig.json
+++ b/examples/calendar/src/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
+    "types": ["node"],
     "outDir": "../dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/examples/coffeeShop/src/tsconfig.json
+++ b/examples/coffeeShop/src/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
+    "types": ["node"],
     "outDir": "../dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/examples/restaurant/src/tsconfig.json
+++ b/examples/restaurant/src/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
+    "types": ["node"],
     "outDir": "../dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/examples/sentiment/src/tsconfig.json
+++ b/examples/sentiment/src/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
+    "types": ["node"],
     "outDir": "../dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
+    "types": ["node"],
     "esModuleInterop": true,
     "outDir": "../dist",
     "skipLibCheck": true,


### PR DESCRIPTION
This change:

* Sets the `--target` to `es2021` so we can get cleaner modern emit.
* Specifies the `--module` setting to `node16`, which more-accurately models behavior when consuming packages.
* Limits the `lib` to remove access to DOM APIs
* Specifies a precise `types` array so that `@types` auto-inclusion is intentionally limited.

Note that this change to `--module` this does not switch our current emit to use ECMAScript modules - we are still emitting CommonJS files. But if we do now consume a package that ships any ESM, or an `exports` field, or whatever, TypeScript will respect it.

The `types` array may need to be updated for global test runners in the future (e.g. Jest maybe?).