### PR TITLE
Fix ENOENT errors when running samples

### DIFF
--- a/examples/calendar/src/main.ts
+++ b/examples/calendar/src/main.ts
@@ -9,7 +9,7 @@ dotenv.config({ path: path.join(__dirname, "../../../.env") });
 
 const calendarChar = "\u{1F4C5}";
 const model = createLanguageModel();
-const schema = fs.readFileSync(path.join(__dirname, "calendarActionsSchema.ts"), "utf8");
+const schema = fs.readFileSync(path.join(__dirname, "../src/calendarActionsSchema.ts"), "utf8");
 const typeChat = createTypeChat<CalendarActions>(model, schema, "CalendarActions");
 typeChat.validator.stripNulls = true;
 

--- a/examples/coffeeShop/src/main.ts
+++ b/examples/coffeeShop/src/main.ts
@@ -9,7 +9,7 @@ dotenv.config({ path: path.join(__dirname, "../../../.env") });
 
 const coffeeCup = "\u{2615}";
 const model = createLanguageModel();
-const schema = fs.readFileSync(path.join(__dirname, "coffeeShopSchema.ts"), "utf8");
+const schema = fs.readFileSync(path.join(__dirname, "../src/coffeeShopSchema.ts"), "utf8");
 const typeChat = createTypeChat<Cart>(model, schema, "Cart");
 
 function processOrder(cart: Cart) {

--- a/examples/restaurant/src/main.ts
+++ b/examples/restaurant/src/main.ts
@@ -14,7 +14,7 @@ dotenv.config({ path: path.join(__dirname, "../../../.env") });
 const pizza = "🍕";
 const model = createLanguageModel();
 const viewSchema = fs.readFileSync(
-  path.join(__dirname, "foodOrderViewSchema.ts"),
+  path.join(__dirname, "../src/foodOrderViewSchema.ts"),
   "utf8"
 );
 const typeChat = createTypeChat<Order>(model, viewSchema, "Order");

--- a/examples/sentiment/src/main.ts
+++ b/examples/sentiment/src/main.ts
@@ -9,7 +9,7 @@ dotenv.config({ path: path.join(__dirname, "../../../.env") });
 
 const happyFace = "\u{1F600}";
 const model = createLanguageModel();
-const schema = fs.readFileSync(path.join(__dirname, "sentimentSchema.ts"), "utf8");
+const schema = fs.readFileSync(path.join(__dirname, "../src/sentimentSchema.ts"), "utf8");
 const typeChat = createTypeChat<SentimentResponse>(model, schema, "SentimentResponse");
 
 // Process requests interactively or from the input file specified on the command line


### PR DESCRIPTION
The path for the schema object can't be resolved after the latest re-organization of files. At runtime, developers will hit:
```
Error: ENOENT: no such file or directory, open '\TypeChatPierce\examples\coffeeShop\dist\coffeeShopSchema.ts'      
    at Object.openSync (node:fs:601:3)
    at Object.readFileSync (node:fs:469:35)
    at Object.<anonymous> (C:\Users\piboggan\Documents\GitHub\TypeChatPierce\examples\coffeeShop\dist\main.js:14:29)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47 {
  errno: -4058,
  syscall: 'open',
  code: 'ENOENT',
  path: '\\TypeChatPierce\\examples\\coffeeShop\\dist\\coffeeShopSchema.ts'
```
To fix, reference the TypeScript schema file in the src directory in each of the samples.