### PR TITLE
Add play playlist functionality to music example

### DIFF
--- a/examples/music/src/chatifyActionsSchema.ts
+++ b/examples/music/src/chatifyActionsSchema.ts
@@ -1,6 +1,8 @@
 // This is a schema for writing programs that control a Spotify music player
 
-export type Track = { name: string }
+export type Playlist = unknown;
+
+export type Track = { name: string };
 export type TrackList = Track[];
 
 export type FavoritesTerm =
@@ -27,7 +29,7 @@ export type PlayTracksOptions = {
     count?: number;
     // index of first track to play; default 0
     offset?: number;
-}
+};
 
 export type FilterTracksArgs = {
     // a filter string, which has the following structure (written as a grammar)
@@ -38,7 +40,7 @@ export type FilterTracksArgs = {
     filter: string;
     // keep the tracks that do not match, instead of the tracks that match; default false
     negate?: boolean;
-}
+};
 
 
 export type API = {
@@ -52,6 +54,8 @@ export type API = {
     pause(): void;
     // List all playlists
     listPlaylists(): void;
+    // Get playlist
+    getPlaylist(name: string): Playlist;
     // Delete playlist 'name'
     deletePlaylist(name: string): void;
     // Set volume
@@ -62,7 +66,7 @@ export type API = {
     // Return the last track list shown to the user
     getLastTrackList(): TrackList;
     // play some or all items from the input list
-    play(trackList: TrackList, options?: PlayTracksOptions): void;
+    play(item: TrackList | Playlist, options?: PlayTracksOptions): void;
     // apply a filter to match tracks; result is the tracks that match the filter
     filterTracks(trackList: TrackList, args: FilterTracksArgs): TrackList;
     // print a list of tracks 

--- a/examples/music/src/endpoints.ts
+++ b/examples/music/src/endpoints.ts
@@ -209,7 +209,8 @@ export async function getPlaybackState(service: SpotifyService) {
 export async function play(
     service: SpotifyService,
     deviceId: string,
-    uris?: string[]
+    uris?: string[],
+    contextUri?: string
 ) {
     const config = {
         headers: {
@@ -219,6 +220,8 @@ export async function play(
     const smallTrack: SpotifyApi.PlayParameterObject = {};
     if (uris) {
         smallTrack.uris = uris;
+    } else if (contextUri) {
+        smallTrack.context_uri = contextUri;
     }
     const playUrl = getUrlWithParams("https://api.spotify.com/v1/me/player/play", { device_id: deviceId });
     try {

--- a/examples/music/src/input.txt
+++ b/examples/music/src/input.txt
@@ -4,3 +4,4 @@ get my top ten tracks since January
 get my favorite 100 tracks from the last two months and show only the ones by Bach
 make it loud
 get my favorite 80 tracks from the last 8 months and create one playlist named class8 containing the classical tracks and another playlist containing the blues tracks
+play my playlist class8

--- a/examples/music/src/main.ts
+++ b/examples/music/src/main.ts
@@ -80,6 +80,18 @@ function printTrackNames(
   }
 }
 
+async function printPlaylist(playlist: SpotifyApi.PlaylistObjectSimplified, context: IClientContext) {
+  console.log(chalk.cyanBright(`Starting playlist --> ${playlist.name}`));
+  console.log(chalk.cyanBright(`--------------------------------------------`));
+  const tracks = await getPlaylistTracks(context.service, playlist.id);
+  const playlistTotalTracks = playlist.tracks.total;
+  console.log(chalk.cyan(`First ${tracks?.items.length} out of ${playlistTotalTracks} songs in list`));
+  tracks?.items.forEach((track, i) => {
+    console.log(chalk.cyan(` ${i < 99 ? i < 9 ? "  " : " " : ""}${i + 1} - ${track.track?.name}`));
+  })
+  console.log(chalk.cyanBright(`--------------------------------------------`));
+}
+
 function uniqueTracks(tracks: SpotifyApi.TrackObjectFull[]) {
   const map = new Map<string, SpotifyApi.TrackObjectFull>();
   for (const track of tracks) {
@@ -378,7 +390,7 @@ async function handleCall(
   args: unknown[],
   clientContext: IClientContext
 ): Promise<unknown> {
-  let result: SpotifyApi.TrackObjectFull[] | undefined = undefined;
+  let result: SpotifyApi.TrackObjectFull[] | SpotifyApi.PlaylistObjectSimplified | undefined = undefined;
   switch (func) {
     case "getLastTrackList": {
       if (clientContext) {
@@ -393,8 +405,8 @@ async function handleCall(
       break;
     }
     case "play": {
-      const input = args[0] as SpotifyApi.TrackObjectFull[];
-      if (input && input.length > 0) {
+      const input = args[0] as SpotifyApi.TrackObjectFull[] | SpotifyApi.PlaylistObjectSimplified;
+      if (Array.isArray(input) && input && input.length > 0) {
         let count = 1;
         let offset = 0;
         let options = args[1] as PlayTracksOptions;
@@ -419,6 +431,12 @@ async function handleCall(
         }
         if (clientContext.deviceId) {
           await play(clientContext.service, clientContext.deviceId, uris);
+        }
+      } else if(!Array.isArray(input) && input && input.type === 'playlist') {
+        const uri = input.uri;
+        if (clientContext.deviceId) {
+          await printPlaylist(input, clientContext);
+          await play(clientContext.service, clientContext.deviceId, undefined, uri);
         }
       } else if (clientContext.deviceId) {
         await play(clientContext.service, clientContext.deviceId);
@@ -520,6 +538,17 @@ async function handleCall(
           console.log(chalk.magentaBright(`${playlist.name}`));
         }
       }
+      break;
+    }
+    case "getPlaylist" : {
+      const playlistName = args[0] as string;
+      const playlists = await getPlaylists(clientContext.service);
+      const playlist = playlists?.items.find(
+        (playlist) => {
+          return playlist.name.toLowerCase().includes(playlistName.toLowerCase());
+        }
+      );
+      result = playlist
       break;
     }
     case "getPlaylistTracks": {


### PR DESCRIPTION
Added the functionality to play a playlist in the music example. This will populate the queue in the Spotify player so you can go forward/back songs.

Before, the first song in the playlist was being played. This does not populate the queue in the Spotify player, so you can not continue listening to the playlist or go to the next song.

Changes:
- Added `getPlaylist` to `chatifyActionsSchema.ts`
- Added `Playlist` type to `chatifyActionsSchema.ts`
- Updated `play` to take in `item: TrackList | Playlist`
- Added `contextUri` param to `play()` in `music/src/endpoints.ts`

![image](https://github.com/microsoft/TypeChat/assets/5473673/b6df2e29-9baa-4672-ab60-5a7bb366395c)

Note:

The `Playlist` type is set to `unknown`. I first tried setting it to `{ name: string }` but, I was getting poor results with this. Using GPT 3.5, it was attempting to pass the name directly into the play function and not the previously found playlist.

| `{ name: string }` | `undefined` |
| ----- | -----|
| ![image](https://github.com/microsoft/TypeChat/assets/5473673/ed1f58f6-2925-44e8-bc91-5b8a3c097edf) | ![image](https://github.com/microsoft/TypeChat/assets/5473673/ddbdc132-bdf9-4d12-a649-ec23a7d59570) |