### PR TITLE
Add next, previous, and shuffle functionality to music example

### DIFF
--- a/examples/music/src/chatifyActionsSchema.ts
+++ b/examples/music/src/chatifyActionsSchema.ts
@@ -40,7 +40,7 @@ export type FilterTracksArgs = {
     negate?: boolean;
 }
 
-export type PlayBackAction = "pause" | "next" | "previous";
+export type PlaybackAction = "pause" | "next" | "previous" | "shuffle";
 
 export type API = {
     // show now playing
@@ -49,10 +49,8 @@ export type API = {
     getPlaylistTracks(name: string): TrackList;
     // Return a list of the user's favorite tracks
     getFavorites(options?: GetFavoritesOptions): TrackList;
-    // Pause playing
-    pause(): void;
     // control playback
-    controlPlayBack(action: PlayBackAction): void;
+    controlPlayback(action: PlaybackAction): void;
     // List all playlists
     listPlaylists(): void;
     // Delete playlist 'name'

--- a/examples/music/src/chatifyActionsSchema.ts
+++ b/examples/music/src/chatifyActionsSchema.ts
@@ -40,6 +40,7 @@ export type FilterTracksArgs = {
     negate?: boolean;
 }
 
+export type PlayBackAction = "pause" | "next" | "previous";
 
 export type API = {
     // show now playing
@@ -50,6 +51,8 @@ export type API = {
     getFavorites(options?: GetFavoritesOptions): TrackList;
     // Pause playing
     pause(): void;
+    // control playback
+    controlPlayBack(action: PlayBackAction): void;
     // List all playlists
     listPlaylists(): void;
     // Delete playlist 'name'

--- a/examples/music/src/endpoints.ts
+++ b/examples/music/src/endpoints.ts
@@ -288,6 +288,60 @@ export async function pause(service: SpotifyService, deviceId: string) {
     }
 }
 
+export async function next(
+    service: SpotifyService,
+    deviceId: string,
+) {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${service.retrieveUser().token}`,
+        },
+    };
+    try {
+        const spotifyResult = await axios.post(
+            `https://api.spotify.com/v1/me/player/next?device_id=${deviceId}`,
+            {},
+            config
+        );
+
+        return spotifyResult.data;
+    } catch (e) {
+        if (e instanceof axios.AxiosError) {
+            console.log(e.message);
+        } else {
+            throw e;
+        }
+    }
+    return undefined;
+}
+
+export async function previous(
+    service: SpotifyService,
+    deviceId: string,
+) {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${service.retrieveUser().token}`,
+        },
+    };
+    try {
+        const spotifyResult = await axios.post(
+            `https://api.spotify.com/v1/me/player/previous?device_id=${deviceId}`,
+            {},
+            config
+        );
+
+        return spotifyResult.data;
+    } catch (e) {
+        if (e instanceof axios.AxiosError) {
+            console.log(e.message);
+        } else {
+            throw e;
+        }
+    }
+    return undefined;
+}
+
 export async function getPlaylists(service: SpotifyService) {
     const config = {
         headers: {
@@ -380,7 +434,6 @@ export async function createPlaylist(
             { name, public: false, description },
             config
         );
-
         const playlistResponse =
             spotifyResult.data as SpotifyApi.CreatePlaylistResponse;
         const addTracksResult = await axios.post(

--- a/examples/music/src/endpoints.ts
+++ b/examples/music/src/endpoints.ts
@@ -342,6 +342,34 @@ export async function previous(
     return undefined;
 }
 
+export async function shuffle(
+    service: SpotifyService,
+    deviceId: string,
+    newShuffleState: boolean
+) {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${service.retrieveUser().token}`,
+        },
+    };
+    try {
+        const spotifyResult = await axios.put(
+            `https://api.spotify.com/v1/me/player/shuffle?state=${newShuffleState}&device_id=${deviceId}`,
+            {},
+            config
+        );
+
+        return spotifyResult.data;
+    } catch (e) {
+        if (e instanceof axios.AxiosError) {
+            console.log(e.message);
+        } else {
+            throw e;
+        }
+    }
+    return undefined;
+}
+
 export async function getPlaylists(service: SpotifyService) {
     const config = {
         headers: {

--- a/examples/music/src/input.txt
+++ b/examples/music/src/input.txt
@@ -4,3 +4,5 @@ get my top ten tracks since January
 get my favorite 100 tracks from the last two months and show only the ones by Bach
 make it loud
 get my favorite 80 tracks from the last 8 months and create one playlist named class8 containing the classical tracks and another playlist containing the blues tracks
+toggle shuffle on and skip to the next track
+go back to the last song

--- a/examples/music/src/main.ts
+++ b/examples/music/src/main.ts
@@ -40,7 +40,8 @@ import {
 import {
   pauseHandler,
   nextHandler,
-  previousHandler
+  previousHandler,
+  shuffleHandler
 } from "./playback";
 import { SpotifyService, User } from "./service";
 
@@ -133,11 +134,11 @@ function chalkPlan(plan: Program) {
 
 function localParser(userPrompt: string) {
   userPrompt = userPrompt.trim();
-  if (userPrompt === "play" || userPrompt === "pause" || userPrompt === "next" || userPrompt === "previous") {
+  if (userPrompt === "play" || userPrompt === "pause" || userPrompt === "next" || userPrompt === "previous" || userPrompt === "shuffle") {
     console.log(chalk.green("Instance parsed locally:"));
     let localParseResult = userPrompt;
     if (userPrompt !== "play") {
-      localParseResult = "controlPlayBack";
+      localParseResult = "controlPlayback";
     }
     return JSON.stringify({
       "@steps": [
@@ -394,13 +395,14 @@ async function handleCall(
       }
       break;
     }
-    case "controlPlayBack" : {
+    case "controlPlayback" : {
       const action = args[0] as string;
 
       const actionHandlers: { [key:string] : (clientContext: IClientContext) => Promise<void> } = {
         pause : pauseHandler,
         next : nextHandler,
-        previous : previousHandler
+        previous : previousHandler,
+        shuffle: shuffleHandler
       };
 
       await actionHandlers[action](clientContext);

--- a/examples/music/src/playback.ts
+++ b/examples/music/src/playback.ts
@@ -1,5 +1,6 @@
 import { IClientContext } from "./main";
-import { pause, next, previous } from "./endpoints";
+import chalk from "chalk";
+import { pause, next, previous, shuffle, getPlaybackState} from "./endpoints";
 
 export async function pauseHandler(clientContext: IClientContext) {
     if (clientContext.deviceId) {
@@ -16,5 +17,18 @@ export async function nextHandler(clientContext: IClientContext) {
 export async function previousHandler(clientContext: IClientContext) {
     if (clientContext.deviceId) {
       await previous(clientContext.service, clientContext.deviceId);
+    }
+}
+
+export async function shuffleHandler(clientContext: IClientContext) {
+    const playbackState = await getPlaybackState(clientContext.service);
+
+    if (playbackState) {
+      const oldShuffleState = playbackState.shuffle_state;
+
+      if (clientContext.deviceId) {
+        console.log(chalk.cyanBright(`Toggling shuffle ${oldShuffleState ? chalk.redBright("off") : chalk.greenBright("on") }`));
+        await shuffle(clientContext.service, clientContext.deviceId, !oldShuffleState);
+      }
     }
 }

--- a/examples/music/src/playback.ts
+++ b/examples/music/src/playback.ts
@@ -1,0 +1,20 @@
+import { IClientContext } from "./main";
+import { pause, next, previous } from "./endpoints";
+
+export async function pauseHandler(clientContext: IClientContext) {
+    if (clientContext.deviceId) {
+      await pause(clientContext.service, clientContext.deviceId);
+    }
+}
+
+export async function nextHandler(clientContext: IClientContext) {
+    if (clientContext.deviceId) {
+      await next(clientContext.service, clientContext.deviceId);
+    }
+}
+
+export async function previousHandler(clientContext: IClientContext) {
+    if (clientContext.deviceId) {
+      await previous(clientContext.service, clientContext.deviceId);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
       },
       "devDependencies": {
         "@types/node": "^20.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/calendar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,6 @@
       },
       "devDependencies": {
         "@types/node": "^20.3.3"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "examples/calendar": {


### PR DESCRIPTION
Added functionality for skipping to the next track, the previous track, and shuffling tracks to the music example. 

### Changes:

- Removed `pause` from the chatify actions API and replaced it with `controlPlayback`.
- Added `PlaybackAction` to the chatify actions as a parameter to `controlPlayback`.
- Added `playback.ts` to contain handlers for the playback state change functions.
- Updated local parser in `main.ts` to handle local parsing of next, previous, and shuffle.

Added new status display for toggling shuffle on and off:

![image](https://github.com/microsoft/TypeChat/assets/60202464/b9d5893f-543a-4c68-97e4-09f14d34e748)
