### PR TITLE
Support OpenAI Organization ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ node_modules/
 *.bat
 
 # Local development and debugging
+.vscode
 **/.vscode/*
 **/tsconfig.debug.json
 !**/.vscode/launch.json
-
+**/build.bat
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -58,8 +58,8 @@ export function createLanguageModel(env: Record<string, string | undefined>): Ty
  * Creates a language model encapsulation of an OpenAI REST API endpoint.
  * @param apiKey The OpenAI API key.
  * @param model The model name.
- * @param org: The OpenAI organization id.
  * @param endPoint The URL of the OpenAI REST API endpoint. Defaults to "https://api.openai.com/v1/chat/completions".
+ * @param org: The OpenAI organization id.
  * @returns An instance of `TypeChatLanguageModel`.
  */
 export function createOpenAILanguageModel(apiKey: string, model: string, endPoint = "https://api.openai.com/v1/chat/completions", org = ""): TypeChatLanguageModel {

--- a/src/model.ts
+++ b/src/model.ts
@@ -44,7 +44,7 @@ export function createLanguageModel(env: Record<string, string | undefined>): Ty
         const model = env.OPENAI_MODEL ?? missingEnvironmentVariable("OPENAI_MODEL");
         const endPoint = env.OPENAI_ENDPOINT ?? "https://api.openai.com/v1/chat/completions";
         const org = env.OPENAI_ORGANIZATION ?? "";
-        return createOpenAILanguageModel(apiKey, model, org, endPoint);
+        return createOpenAILanguageModel(apiKey, model, endPoint, org);
     }
     if (env.AZURE_OPENAI_API_KEY) {
         const apiKey = env.AZURE_OPENAI_API_KEY ?? missingEnvironmentVariable("AZURE_OPENAI_API_KEY");
@@ -62,7 +62,7 @@ export function createLanguageModel(env: Record<string, string | undefined>): Ty
  * @param endPoint The URL of the OpenAI REST API endpoint. Defaults to "https://api.openai.com/v1/chat/completions".
  * @returns An instance of `TypeChatLanguageModel`.
  */
-export function createOpenAILanguageModel(apiKey: string, model: string, org: string, endPoint = "https://api.openai.com/v1/chat/completions"): TypeChatLanguageModel {
+export function createOpenAILanguageModel(apiKey: string, model: string, endPoint = "https://api.openai.com/v1/chat/completions", org = ""): TypeChatLanguageModel {
     return createAxiosLanguageModel(endPoint, { 
         headers: { 
             Authorization: `Bearer ${apiKey}`,

--- a/src/model.ts
+++ b/src/model.ts
@@ -43,7 +43,8 @@ export function createLanguageModel(env: Record<string, string | undefined>): Ty
         const apiKey = env.OPENAI_API_KEY ?? missingEnvironmentVariable("OPENAI_API_KEY");
         const model = env.OPENAI_MODEL ?? missingEnvironmentVariable("OPENAI_MODEL");
         const endPoint = env.OPENAI_ENDPOINT ?? "https://api.openai.com/v1/chat/completions";
-        return createOpenAILanguageModel(apiKey, model, endPoint);
+        const org = env.OPENAI_ORGANIZATION ?? "";
+        return createOpenAILanguageModel(apiKey, model, org, endPoint);
     }
     if (env.AZURE_OPENAI_API_KEY) {
         const apiKey = env.AZURE_OPENAI_API_KEY ?? missingEnvironmentVariable("AZURE_OPENAI_API_KEY");
@@ -57,11 +58,17 @@ export function createLanguageModel(env: Record<string, string | undefined>): Ty
  * Creates a language model encapsulation of an OpenAI REST API endpoint.
  * @param apiKey The OpenAI API key.
  * @param model The model name.
+ * @param org: The OpenAI organization id.
  * @param endPoint The URL of the OpenAI REST API endpoint. Defaults to "https://api.openai.com/v1/chat/completions".
  * @returns An instance of `TypeChatLanguageModel`.
  */
-export function createOpenAILanguageModel(apiKey: string, model: string, endPoint = "https://api.openai.com/v1/chat/completions",): TypeChatLanguageModel {
-    return createAxiosLanguageModel(endPoint, { headers: { Authorization: `Bearer ${apiKey}` } }, { model });
+export function createOpenAILanguageModel(apiKey: string, model: string, org: string, endPoint = "https://api.openai.com/v1/chat/completions"): TypeChatLanguageModel {
+    return createAxiosLanguageModel(endPoint, { 
+        headers: { 
+            Authorization: `Bearer ${apiKey}`,
+            "OpenAI-Organization": org
+         } 
+    }, { model });
 }
 
 /**


### PR DESCRIPTION
Some Open AI users can belong to multiple organizations within the same account.  This PR adds support for including **OpenAI-Organization** header. 

[https://platform.openai.com/docs/api-reference/requesting-organization](url)

The PR also includes a few additions to .gitignore
