### PR TITLE
fix unnecessary colon in JSDoc

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -26,11 +26,11 @@ export interface TypeChatLanguageModel {
 /**
  * Creates a language model encapsulation of an OpenAI or Azure OpenAI REST API endpoint
  * chosen by environment variables.
- * 
+ *
  * If an `OPENAI_API_KEY` environment variable exists, the `createOpenAILanguageModel` function
  * is used to create the instance. The `OPENAI_ENDPOINT` and `OPENAI_MODEL` environment variables
  * must also be defined or an exception will be thrown.
- * 
+ *
  * If an `AZURE_OPENAI_API_KEY` environment variable exists, the `createAzureOpenAILanguageModel` function
  * is used to create the instance. The `AZURE_OPENAI_ENDPOINT` environment variable must also be defined
  * or an exception will be thrown.
@@ -59,15 +59,15 @@ export function createLanguageModel(env: Record<string, string | undefined>): Ty
  * @param apiKey The OpenAI API key.
  * @param model The model name.
  * @param endPoint The URL of the OpenAI REST API endpoint. Defaults to "https://api.openai.com/v1/chat/completions".
- * @param org: The OpenAI organization id.
+ * @param org The OpenAI organization id.
  * @returns An instance of `TypeChatLanguageModel`.
  */
 export function createOpenAILanguageModel(apiKey: string, model: string, endPoint = "https://api.openai.com/v1/chat/completions", org = ""): TypeChatLanguageModel {
-    return createAxiosLanguageModel(endPoint, { 
-        headers: { 
+    return createAxiosLanguageModel(endPoint, {
+        headers: {
             Authorization: `Bearer ${apiKey}`,
             "OpenAI-Organization": org
-         } 
+         }
     }, { model });
 }
 


### PR DESCRIPTION
Changes Made:

Removed the colon after "@param org" in the JSDoc comments.

Reason for the Change:
The JSDoc comments were updated to adhere to the convention of not including a colon after the "@param" tag.
