### PR TITLE
Add HTTP_PROXY variable and proxy process when access endpoints' api services

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -89,6 +89,13 @@ AZURE_OPENAI_ENDPOINT=...
 AZURE_OPENAI_API_KEY=...
 ```
 
+Optional proxy setting: For some endpoints, proxy is needed to access services.
+You can set your http proxy environment variable that looks like the following:
+```
+# For Proxy
+HTTP_PROXY=http://host:port
+```
+
 ## Step 4: Run the examples
 
 Examples can be found in the `examples` directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,14 @@
       ],
       "dependencies": {
         "axios": "^1.4.0",
+        "https-proxy-agent": "^7.0.1",
         "typescript": "^5.1.3"
       },
       "devDependencies": {
         "@types/node": "^20.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/calendar": {
@@ -222,6 +226,38 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -820,6 +856,39 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "dependencies": {
     "axios": "^1.4.0",
+    "https-proxy-agent": "^7.0.1",
     "typescript": "^5.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Some area and use cases can't access to endpoints' services directly, like OpenAI's api.
I add some process to let the code read HTTP_PROXY enviroment variable from `.env` file first (if it was set), and use proxy to access endpoints' services and api, when `createLanguageModel`.