### PR TITLE
Add types and functionality to pass through api-information about usage etc. from OpenAI

### DIFF
--- a/examples/sentiment/src/main.ts
+++ b/examples/sentiment/src/main.ts
@@ -18,5 +18,6 @@ processRequests("😀> ", process.argv[2], async (request) => {
         console.log(response.message);
         return;
     }
-    console.log(`The sentiment is ${response.data.sentiment}`);
+
+    console.log(`The sentiment is ${response.data.sentiment}. The request used ${response.api?.usage.total_tokens ?? -1} tokens.`);
 });

--- a/src/model.ts
+++ b/src/model.ts
@@ -104,9 +104,14 @@ function createAxiosLanguageModel(url: string, config: object, defaultParams: Re
                 temperature: 0,
                 n: 1
             };
-            const result = await client.post(url, params, { validateStatus: status => true });
+            const result = await client.post(url, params, {
+                validateStatus: (_status) => true
+            });
+
+            const { choices, ...apiData } = result.data;
+
             if (result.status === 200) {
-                return success(result.data.choices[0].message?.content ?? "");
+                return success(result.data.choices[0].message?.content ?? "", apiData);
             }
             if (!isTransientHttpError(result.status) || retryCount >= retryMaxAttempts) {
                 return error(`REST API error ${result.status}: ${result.statusText}`);

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,12 +1,16 @@
 /**
  * An object representing a successful operation with a result of type `T`.
  */
-export type Success<T> = { success: true, data: T };
+export type Success<T> = {
+    success: true;
+    data: T;
+    api?: OpenAiInfo;
+};
 
 /**
  * An object representing an operation that failed for the reason given in `message`.
  */
-export type Error = { success: false, message: string };
+export type Error = { success: false; message: string };
 
 /**
  * An object representing a successful or failed operation of type `T`.
@@ -14,12 +18,29 @@ export type Error = { success: false, message: string };
 export type Result<T> = Success<T> | Error;
 
 /**
+ * An object containing the information returned by the OpenAI-Api. It contains
+ * information on the tokens used, the model used, a timestamp, and the specific
+ * id the prompt has in the backend.
+ */
+export type OpenAiInfo = {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    usage: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+    };
+};
+
+/**
  * Returns a `Success<T>` object.
  * @param data The value for the `data` property of the result.
  * @returns A `Success<T>` object.
  */
-export function success<T>(data: T): Success<T> {
-    return { success: true, data };
+export function success<T>(data: T, info?: OpenAiInfo): Success<T> {
+    return info ? { success: true, data, api: info } : { success: true, data };
 }
 
 /**

--- a/src/typechat.ts
+++ b/src/typechat.ts
@@ -97,7 +97,9 @@ export function createJsonTranslator<T extends object>(model: TypeChatLanguageMo
             if (!response.success) {
                 return response;
             }
-            const responseText = response.data;
+
+            const { api, data: responseText } = response;
+
             const startIndex = responseText.indexOf("{");
             const endIndex = responseText.lastIndexOf("}");
             if (!(startIndex >= 0 && endIndex > startIndex)) {
@@ -106,7 +108,7 @@ export function createJsonTranslator<T extends object>(model: TypeChatLanguageMo
             const jsonText = responseText.slice(startIndex, endIndex + 1);
             const validation = validator.validate(jsonText);
             if (validation.success) {
-                return validation;
+                return api ? { ...validation, api } : validation;
             }
             if (!attemptRepair) {
                 return error(`JSON validation failed: ${validation.message}\n${jsonText}`);


### PR DESCRIPTION
I added the option to access the information OpenAI adds to the response about total usage etc. For this I had to modify the types slightly and adjusted the example for sentiment analysis to print the amount of tokens used.

Not sure if this works with Azure instances as well, because I don't have such an instance running.