### PR TITLE
Add getQueue functionality to music example

### DIFF
--- a/examples/music/src/chatifyActionsSchema.ts
+++ b/examples/music/src/chatifyActionsSchema.ts
@@ -16,6 +16,8 @@ export type API = {
     ): void;
     // print a list of tracks
     printTracks(trackList: TrackList): void;
+    // see what is up next
+    getQueue(): void;
     // show now playing
     status(): void;
     // control playback

--- a/examples/music/src/endpoints.ts
+++ b/examples/music/src/endpoints.ts
@@ -336,20 +336,19 @@ export async function pause(service: SpotifyService, deviceId: string) {
     }
 }
 
-export async function next(service: SpotifyService, deviceId: string) {
+export async function getQueue(service: SpotifyService) {
     const config = {
         headers: {
             Authorization: `Bearer ${service.retrieveUser().token}`,
         },
     };
     try {
-        const spotifyResult = await axios.post(
-            `https://api.spotify.com/v1/me/player/next?device_id=${deviceId}`,
-            {},
+        const spotifyResult = await axios.get(
+            `https://api.spotify.com/v1/me/player/queue`,
             config
         );
 
-        return spotifyResult.data;
+        return spotifyResult.data as SpotifyApi.UsersQueueResponse;
     } catch (e) {
         if (e instanceof axios.AxiosError) {
             console.log(e.message);
@@ -397,6 +396,30 @@ export async function shuffle(
     try {
         const spotifyResult = await axios.put(
             `https://api.spotify.com/v1/me/player/shuffle?state=${newShuffleState}&device_id=${deviceId}`,
+            {},
+            config
+        );
+
+        return spotifyResult.data;
+    } catch (e) {
+        if (e instanceof axios.AxiosError) {
+            console.log(e.message);
+        } else {
+            throw e;
+        }
+    }
+    return undefined;
+}
+
+export async function next(service: SpotifyService, deviceId: string) {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${service.retrieveUser().token}`,
+        },
+    };
+    try {
+        const spotifyResult = await axios.post(
+            `https://api.spotify.com/v1/me/player/next?device_id=${deviceId}`,
             {},
             config
         );

--- a/examples/music/src/input.txt
+++ b/examples/music/src/input.txt
@@ -7,3 +7,6 @@ toggle shuffle on and skip to the next track
 go back to the last song
 play my playlist class8
 play the fourth one
+show me my queue
+display the queue
+what is my queue?

--- a/examples/music/src/main.ts
+++ b/examples/music/src/main.ts
@@ -38,6 +38,7 @@ import {
     previous,
     shuffle,
     getAlbumTracks,
+    getQueue,
 } from "./endpoints";
 import { listAvailableDevices, printStatus, selectDevice } from "./playback";
 import { SpotifyService, User } from "./service";
@@ -229,6 +230,23 @@ async function handleCall(
         }
         case "status": {
             await printStatus(clientContext);
+            break;
+        }
+        case "getQueue": {
+            const currentQueue = await getQueue(clientContext.service);
+            if (currentQueue) {
+                // not yet supporting episidoes
+                const filtered = currentQueue.queue.filter((item) => item.type === "track") as SpotifyApi.TrackObjectFull[];
+                console.log(chalk.magentaBright("Current Queue:"));
+                console.log(
+                    chalk.cyanBright(`--------------------------------------------`)
+                );
+                await printTrackNames(filtered, clientContext);
+                console.log(
+                    chalk.cyanBright(`--------------------------------------------`)
+                );
+                await printStatus(clientContext);
+            }
             break;
         }
         case "pause": {


### PR DESCRIPTION
When using the music example, I found I wanted to see what tracks were up next in my queue. This PR adds functionality to show the current queue up to the next 20 tracks.

### Changes
- Added `getQueue()` to the chatify actions API
- Added a `getQueue` function to `endpoints.ts`
- Added a handler in `main.ts` to get and print the queue using the existing `printTrackNames` function
- Added visualizations to make it easier to see were the queue begins and ends:

<img width="488" alt="image" src="https://github.com/microsoft/TypeChat/assets/60202464/d75e7ea3-e84e-425f-a49f-66021c76eb3b">
