### PR TITLE
Added Promptrix to TypeChat

### DIFF
--- a/examples/music/package.json
+++ b/examples/music/package.json
@@ -14,6 +14,7 @@
     "chalk": "^2.3.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "promptrix": "^0.4.2",
     "open": "^7.0.4"
   },
   "devDependencies": {

--- a/examples/music/src/main.ts
+++ b/examples/music/src/main.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { UserMessage } from "promptrix";
 import { Authzor } from "./authz";
 import chalk from "chalk";
 import dotenv from "dotenv";
@@ -514,7 +515,7 @@ async function handleCall(
         }
         case "nonMusicQuestion": {
             const text = args[0] as string;
-            const ret = await model.complete(text);
+            const ret = await model.complete(new UserMessage(text));
             if (ret.success) {
                 console.log(ret.data);
             }

--- a/examples/music/src/trackFilter.ts
+++ b/examples/music/src/trackFilter.ts
@@ -1,3 +1,4 @@
+import { UserMessage } from "promptrix";
 import { TypeChatLanguageModel } from "../../../dist";
 import { getArtist } from "./endpoints";
 import { IClientContext } from "./main";
@@ -419,7 +420,7 @@ async function llmFilter(
         trackNumbers: number[];
     };\n`;
     prompt += `Here is a JSON object of type Matches containing the track numbers of the tracks that match ${description}:\n`;
-    const ret = await model.complete(prompt);
+    const ret = await model.complete(new UserMessage(prompt));
     return ret;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,14 @@
       ],
       "dependencies": {
         "axios": "^1.4.0",
+        "promptrix": "^0.4.2",
         "typescript": "^5.1.3"
       },
       "devDependencies": {
         "@types/node": "^20.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/calendar": {
@@ -765,6 +769,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gpt-3-encoder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
+      "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1071,6 +1080,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/promptrix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/promptrix/-/promptrix-0.4.2.tgz",
+      "integrity": "sha512-/AiuGZHqPRPCUnEHHz0g8YCRIFKwWO6TYHdv6iqhCUdAjp6BMAfSEX/wGLmwzY29PsP5//FiQ/AfDF2tOCtqtQ==",
+      "dependencies": {
+        "gpt-3-encoder": "1.1.4",
+        "yaml": "^1.10.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1430,6 +1448,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "dependencies": {
     "axios": "^1.4.0",
+    "promptrix": "^0.4.2",
     "typescript": "^5.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Added Promptrix support to TypeChat library and examples.  Translator now returns a `PromptSection` and the model interface has been updated to take `PromptSection` as input along with optional `PromptMemory` and `PromptFunctions` objects which are needed by the renderer. 

This change should put TypeChat in a great position to add support for conversation history and a more chat like experience.