### PR TITLE
Add typechat to example package deps

### DIFF
--- a/examples/calendar/package.json
+++ b/examples/calendar/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "typechat": "^0.0.10"
   },
   "devDependencies": {
     "@types/node": "^20.3.1",

--- a/examples/coffeeShop/package.json
+++ b/examples/coffeeShop/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "typechat": "^0.0.10"
   },
   "devDependencies": {
     "@types/node": "^20.3.1",

--- a/examples/math/package.json
+++ b/examples/math/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "typechat": "^0.0.10"
   },
   "devDependencies": {
     "@types/node": "^20.3.1",

--- a/examples/music/package.json
+++ b/examples/music/package.json
@@ -14,7 +14,8 @@
     "chalk": "^2.3.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "open": "^7.0.4"
+    "open": "^7.0.4",
+    "typechat": "^0.0.10"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/examples/restaurant/package.json
+++ b/examples/restaurant/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "typechat": "^0.0.10"
   },
   "devDependencies": {
     "@types/node": "^20.3.1",

--- a/examples/sentiment/package.json
+++ b/examples/sentiment/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "typechat": "^0.0.10"
   },
   "devDependencies": {
     "@types/node": "^20.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,17 @@
       },
       "devDependencies": {
         "@types/node": "^20.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/calendar": {
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "typechat": "^0.0.10"
       },
       "devDependencies": {
         "@types/node": "^20.3.1",
@@ -50,7 +54,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "typechat": "^0.0.10"
       },
       "devDependencies": {
         "@types/node": "^20.3.1",
@@ -62,7 +67,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "typechat": "^0.0.10"
       },
       "devDependencies": {
         "@types/node": "^20.3.1",
@@ -77,7 +83,8 @@
         "chalk": "^2.3.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "open": "^7.0.4"
+        "open": "^7.0.4",
+        "typechat": "^0.0.10"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
@@ -91,7 +98,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "typechat": "^0.0.10"
       },
       "devDependencies": {
         "@types/node": "^20.3.1",
@@ -103,7 +111,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "typechat": "^0.0.10"
       },
       "devDependencies": {
         "@types/node": "^20.3.1",


### PR DESCRIPTION
This is an alternative to #89, and also fixes #81.

This worked for me but not for @DanielRosenwasser; I did see a bunch of time spent idealTree-ing but that happens when you change the tree, it seems.

There are other reasons to take #89 instead, mainly, perf.