### PR TITLE
examples: fix "main" entry point in package.json

### DIFF
--- a/examples/calendar/package.json
+++ b/examples/calendar/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "",
-  "main": "index.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p src",
     "postbuild": "copyfiles -u 1 src/**/*Schema.ts src/**/*.txt dist"

--- a/examples/coffeeShop/package.json
+++ b/examples/coffeeShop/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "",
-  "main": "index.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p src",
     "postbuild": "copyfiles -u 1 src/**/*Schema.ts src/**/*.txt dist"

--- a/examples/math/package.json
+++ b/examples/math/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "",
-  "main": "index.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p src",
     "postbuild": "copyfiles -u 1 src/**/*Schema.ts src/**/*.txt dist"

--- a/examples/music/package.json
+++ b/examples/music/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "",
-  "main": "index.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p src",
     "postbuild": "copyfiles -u 1 src/**/*Schema.ts src/**/*.txt src/**/*.html dist"

--- a/examples/restaurant/package.json
+++ b/examples/restaurant/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "",
-  "main": "index.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p src",
     "postbuild": "copyfiles -u 1 src/**/*Schema.ts src/**/*.txt dist"

--- a/examples/sentiment/package.json
+++ b/examples/sentiment/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "",
-  "main": "index.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p src",
     "postbuild": "copyfiles -u 1 src/**/*Schema.ts src/**/*.txt dist"


### PR DESCRIPTION
The "main" entry point for the samples previously pointed to the non-existent 'index.js'.

Fixing this allows people to run samples with the shorthand `node .`, which consults ./package.json for the entry point.

Of course, `node ./dist/main.js` still works too.

I did not update the readme or examples.md to use `node .`, since I thought this was less obvious, but can if desired.