### PR TITLE
Add support for prompt roles and prompt preambles

### DIFF
--- a/src/typechat.ts
+++ b/src/typechat.ts
@@ -1,5 +1,5 @@
 import { Result, error } from "./result";
-import { TypeChatLanguageModel } from "./model";
+import { TypeChatLanguageModel, PromptSection } from "./model";
 import { TypeChatJsonValidator, createJsonValidator } from "./validate";
 
 /**
@@ -48,9 +48,11 @@ export interface TypeChatJsonTranslator<T extends object> {
      * attempt to translate the request will be made. The prompt for the second attempt will include the
      * diagnostics produced for the first attempt. This often helps produce a valid instance.
      * @param request The natural language request.
+     * @param promptPreamble An optional string or array of prompt sections to prepend to the generated
+     *   prompt. If a string is specified, it is converted into a single "user" role prompt section.
      * @returns A promise for the resulting object.
      */
-    translate(request: string): Promise<Result<T>>;
+    translate(request: string, promptPreamble?: string | PromptSection[]): Promise<Result<T>>;
 }
 
 /**
@@ -89,8 +91,9 @@ export function createJsonTranslator<T extends object>(model: TypeChatLanguageMo
             `The following is a revised JSON object:\n`;
     }
 
-    async function translate(request: string) {
-        let prompt = typeChat.createRequestPrompt(request);
+    async function translate(request: string, promptPreamble?: string | PromptSection[]) {
+        const preamble: PromptSection[] = typeof promptPreamble === "string" ? [{ role: "user", content: promptPreamble }] : promptPreamble ?? [];
+        let prompt: PromptSection[] = [...preamble, { role: "user", content: typeChat.createRequestPrompt(request) }];
         let attemptRepair = typeChat.attemptRepair;
         while (true) {
             const response = await model.complete(prompt);
@@ -111,7 +114,8 @@ export function createJsonTranslator<T extends object>(model: TypeChatLanguageMo
             if (!attemptRepair) {
                 return error(`JSON validation failed: ${validation.message}\n${jsonText}`);
             }
-            prompt += `${responseText}\n${typeChat.createRepairPrompt(validation.message)}`;
+            prompt.push({ role: "assistant", content: responseText });
+            prompt.push({ role: "user", content: typeChat.createRepairPrompt(validation.message) });
             attemptRepair = false;
         }
     }


### PR DESCRIPTION
This PR adds support for prompt roles, i.e. prompt sections tagged with `"system"`, `"user"`, or `"assistant"` roles. TypeChat uses the `"user"` role for prompts it generates and the `"assistant"` role for previous LLM responses (which will be part of the prompt in repair attempts). TypeChat currently doesn't use the `"system"` role.

This PR also adds support for specifying a prompt preamble when processing requests. This makes it easier to implement chat-like interactions and conversation history.