### PR TITLE
Fix authentication issue when using managed identity on Azure

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -97,7 +97,14 @@ export function createOpenAILanguageModel(apiKey: string, model: string, endPoin
  * @returns An instance of `TypeChatLanguageModel`.
  */
 export function createAzureOpenAILanguageModel(apiKey: string, endPoint: string,): TypeChatLanguageModel {
-    return createAxiosLanguageModel(endPoint, { headers: { "api-key": apiKey } }, {});
+    return createAxiosLanguageModel(endPoint, {
+        headers: {
+            // Needed when using managed identity
+            Authorization: `Bearer ${apiKey}`,
+            // Needed when using regular API key
+            "api-key": apiKey
+        }
+    }, {});
 }
 
 /**


### PR DESCRIPTION
When using [managed identity](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity) on Azure, the current code is not working and returning 401 errors.

The header `Authorization: `Bearer ${apiKey}` needs to be set for that use case.

I can also add a note in the documentation on how to use Azure managed identity if you want, let me know.