### PR TITLE
Python: Add sentiment, calendar, and restaurant examples

### DIFF
--- a/python/.devcontainer/devcontainer.json
+++ b/python/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [7860,7861,7862,7863,7864,7865,7866,7867,7868,7869,7870],
 
 
 	// Configure tool-specific properties.

--- a/python/examples/calendar/demo.py
+++ b/python/examples/calendar/demo.py
@@ -1,0 +1,30 @@
+import asyncio
+import json
+
+import sys
+from dotenv import dotenv_values
+import schema as calendar
+from typechat import Failure, TypeChatTranslator, TypeChatValidator, create_language_model
+
+
+async def main():
+    vals = dotenv_values()
+    model = create_language_model(vals)
+    validator = TypeChatValidator(calendar.CalendarActions)
+    translator = TypeChatTranslator(model, validator, calendar.CalendarActions)
+    print("📅> ", end="", flush=True)
+    for line in sys.stdin:
+        result = await translator.translate(line)
+        if isinstance(result, Failure):
+            print("Translation Failed ❌")
+            print(f"Context: {result.message}")
+        else:
+            result = result.value
+            print("Translation Succeeded! ✅\n")
+            print("JSON View")
+            print(json.dumps(result, indent=2))
+        print("\n📅> ", end="", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/examples/calendar/schema.py
+++ b/python/examples/calendar/schema.py
@@ -1,5 +1,8 @@
 from typing import Literal, NotRequired, TypedDict, Annotated
-def Doc(s: str) -> str: return s
+
+
+def Doc(s: str) -> str:
+    return s
 
 
 class UnknownAction(TypedDict):
@@ -11,10 +14,10 @@ class UnknownAction(TypedDict):
     text: Annotated[str, Doc("text typed by the user that the system did not understand")]
 
 
-class EventTimeRange(TypedDict):
-    startTime: NotRequired[str]
-    endTime: NotRequired[str]
-    duration: NotRequired[str]
+class EventTimeRange(TypedDict, total=False):
+    startTime: str
+    endTime: str
+    duration: str
 
 
 class Event(TypedDict):
@@ -25,18 +28,18 @@ class Event(TypedDict):
     participants: NotRequired[Annotated[list[str], Doc("a list of people or named groups like 'team'")]]
 
 
-class EventReference(TypedDict):
+class EventReference(TypedDict, total=False):
     """
     properties used by the requester in referring to an event
     these properties are only specified if given directly by the requester
     """
 
-    day: NotRequired[Annotated[str, Doc("date (example: March 22, 2024) or relative date (example: after EventReference)")]]
-    dayRange: NotRequired[Annotated[str, Doc("(examples: this month, this week, in the next two days)")]]
-    timeRange: NotRequired[EventTimeRange]
-    description: NotRequired[str]
-    location: NotRequired[str]
-    participants: NotRequired[list[str]]
+    day: Annotated[str, Doc("date (example: March 22, 2024) or relative date (example: after EventReference)")]
+    dayRange: Annotated[str, Doc("(examples: this month, this week, in the next two days)")]
+    timeRange: EventTimeRange
+    description: str
+    location: str
+    participants: list[str]
 
 
 class FindEventsAction(TypedDict):
@@ -71,7 +74,7 @@ class RemoveEventAction(TypedDict):
 
 class AddEventAction(TypedDict):
     actionType: Literal["add event"]
-    eventReference: Event
+    event: Event
 
 
 Actions = (

--- a/python/examples/calendar/schema.py
+++ b/python/examples/calendar/schema.py
@@ -1,0 +1,89 @@
+from typing import Literal, NotRequired, TypedDict, Annotated
+def Doc(s: str) -> str: return s
+
+
+class UnknownAction(TypedDict):
+    """
+    if the user types text that can not easily be understood as a calendar action, this action is used
+    """
+
+    actionType: Literal["Unknown"]
+    text: Annotated[str, Doc("text typed by the user that the system did not understand")]
+
+
+class EventTimeRange(TypedDict):
+    startTime: NotRequired[str]
+    endTime: NotRequired[str]
+    duration: NotRequired[str]
+
+
+class Event(TypedDict):
+    day: Annotated[str, Doc("date (example: March 22, 2024) or relative date (example: after EventReference)")]
+    timeRange: EventTimeRange
+    description: str
+    location: NotRequired[str]
+    participants: NotRequired[Annotated[list[str], Doc("a list of people or named groups like 'team'")]]
+
+
+class EventReference(TypedDict):
+    """
+    properties used by the requester in referring to an event
+    these properties are only specified if given directly by the requester
+    """
+
+    day: NotRequired[Annotated[str, Doc("date (example: March 22, 2024) or relative date (example: after EventReference)")]]
+    dayRange: NotRequired[Annotated[str, Doc("(examples: this month, this week, in the next two days)")]]
+    timeRange: NotRequired[EventTimeRange]
+    description: NotRequired[str]
+    location: NotRequired[str]
+    participants: NotRequired[list[str]]
+
+
+class FindEventsAction(TypedDict):
+    actionType: Literal["find events"]
+    eventReference: Annotated[EventReference, Doc("one or more event properties to use to search for matching events")]
+
+
+class ChangeDescriptionAction(TypedDict):
+    actionType: Literal["change description"]
+    eventReference: NotRequired[Annotated[EventReference, Doc("event to be changed")]]
+    description: Annotated[str, Doc("new description for the event")]
+
+
+class ChangeTimeRangeAction(TypedDict):
+    actionType: Literal["change time range"]
+    eventReference: NotRequired[Annotated[EventReference, Doc("event to be changed")]]
+    timeRange: Annotated[EventTimeRange, Doc("new time range for the event")]
+
+
+class AddParticipantsAction(TypedDict):
+    actionType: Literal["add participants"]
+    eventReference: NotRequired[
+        Annotated[EventReference, Doc("event to be augmented; if not specified assume last event discussed")]
+    ]
+    participants: NotRequired[Annotated[list[str], "new participants (one or more)"]]
+
+
+class RemoveEventAction(TypedDict):
+    actionType: Literal["remove event"]
+    eventReference: EventReference
+
+
+class AddEventAction(TypedDict):
+    actionType: Literal["add event"]
+    eventReference: Event
+
+
+Actions = (
+    AddEventAction
+    | RemoveEventAction
+    | AddParticipantsAction
+    | ChangeTimeRangeAction
+    | ChangeDescriptionAction
+    | FindEventsAction
+    | UnknownAction
+)
+
+
+class CalendarActions(TypedDict):
+    actions: list[Actions]

--- a/python/examples/restaurant/demo.py
+++ b/python/examples/restaurant/demo.py
@@ -1,0 +1,30 @@
+import asyncio
+import json
+
+import sys
+from dotenv import dotenv_values
+import schema as restaurant
+from typechat import Failure, TypeChatTranslator, TypeChatValidator, create_language_model
+
+
+async def main():
+    vals = dotenv_values()
+    model = create_language_model(vals)
+    validator = TypeChatValidator(restaurant.Order)
+    translator = TypeChatTranslator(model, validator, restaurant.Order)
+    print("🍕> ", end="", flush=True)
+    for line in sys.stdin:
+        result = await translator.translate(line)
+        if isinstance(result, Failure):
+            print("Translation Failed ❌")
+            print(f"Context: {result.message}")
+        else:
+            result = result.value
+            print("Translation Succeeded! ✅\n")
+            print("JSON View")
+            print(json.dumps(result, indent=2))
+        print("\n🍕> ", end="", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/examples/restaurant/schema.py
+++ b/python/examples/restaurant/schema.py
@@ -1,5 +1,8 @@
-from typing import Literal, NotRequired, TypedDict, Annotated
-def Doc(s: str) -> str: return s
+from typing import Literal, Required, NotRequired, TypedDict, Annotated
+
+
+def Doc(s: str) -> str:
+    return s
 
 
 class UnknownText(TypedDict):
@@ -11,19 +14,15 @@ class UnknownText(TypedDict):
     text: Annotated[str, "The text that wasn't understood"]
 
 
-class Pizza(TypedDict):
-    itemType: Literal["Pizza"]
-    size: NotRequired[Annotated[Literal["small", "medium", "large", "extra large"], "default: large"]]
-    addedToppings: NotRequired[Annotated[list[str], Doc("toppings requested (examples: pepperoni, arugula)")]]
-    removedToppings: NotRequired[
-        Annotated[list[str], Doc("toppings requested to be removed (examples: fresh garlic, anchovies)")]
-    ]
-    quantity: NotRequired[Annotated[int, "default: 1"]]
-    name: NotRequired[
-        Annotated[
-            Literal["Hawaiian", "Yeti", "Pig In a Forest", "Cherry Bomb"],
-            Doc("used if the requester references a pizza by name"),
-        ]
+class Pizza(TypedDict, total=False):
+    itemType: Required[Literal["Pizza"]]
+    size: Annotated[Literal["small", "medium", "large", "extra large"], "default: large"]
+    addedToppings: Annotated[list[str], Doc("toppings requested (examples: pepperoni, arugula)")]
+    removedToppings: Annotated[list[str], Doc("toppings requested to be removed (examples: fresh garlic, anchovies)")]
+    quantity: Annotated[int, "default: 1"]
+    name: Annotated[
+        Literal["Hawaiian", "Yeti", "Pig In a Forest", "Cherry Bomb"],
+        Doc("used if the requester references a pizza by name"),
     ]
 
 
@@ -38,13 +37,13 @@ SaladSize = Literal["half", "whole"]
 SaladStyle = Literal["Garden", "Greek"]
 
 
-class Salad(TypedDict):
-    itemType: Literal["Salad"]
-    portion: NotRequired[Annotated[str, "default: half"]]
-    style: NotRequired[Annotated[str, "default: Garden"]]
-    addedIngredients: NotRequired[Annotated[list[str], Doc("ingredients requested (examples: parmesan, croutons)")]]
-    removedIngredients: NotRequired[Annotated[list[str], Doc("ingredients requested to be removed (example: red onions)")]]
-    quantity: NotRequired[Annotated[int, "default: 1"]]
+class Salad(TypedDict, total=False):
+    itemType: Required[Literal["Salad"]]
+    portion: Annotated[str, "default: half"]
+    style: Annotated[str, "default: Garden"]
+    addedIngredients: Annotated[list[str], Doc("ingredients requested (examples: parmesan, croutons)")]
+    removedIngredients: Annotated[list[str], Doc("ingredients requested to be removed (example: red onions)")]
+    quantity: Annotated[int, "default: 1"]
 
 
 OrderItem = Pizza | Beer | Salad

--- a/python/examples/restaurant/schema.py
+++ b/python/examples/restaurant/schema.py
@@ -1,0 +1,54 @@
+from typing import Literal, NotRequired, TypedDict, Annotated
+def Doc(s: str) -> str: return s
+
+
+class UnknownText(TypedDict):
+    """
+    Use this type for order items that match nothing else
+    """
+
+    itemType: Literal["UnknownText"]
+    text: Annotated[str, "The text that wasn't understood"]
+
+
+class Pizza(TypedDict):
+    itemType: Literal["Pizza"]
+    size: NotRequired[Annotated[Literal["small", "medium", "large", "extra large"], "default: large"]]
+    addedToppings: NotRequired[Annotated[list[str], Doc("toppings requested (examples: pepperoni, arugula)")]]
+    removedToppings: NotRequired[
+        Annotated[list[str], Doc("toppings requested to be removed (examples: fresh garlic, anchovies)")]
+    ]
+    quantity: NotRequired[Annotated[int, "default: 1"]]
+    name: NotRequired[
+        Annotated[
+            Literal["Hawaiian", "Yeti", "Pig In a Forest", "Cherry Bomb"],
+            Doc("used if the requester references a pizza by name"),
+        ]
+    ]
+
+
+class Beer(TypedDict):
+    itemType: Literal["Beer"]
+    kind: Annotated[str, Doc("examples: Mack and Jacks, Sierra Nevada Pale Ale, Miller Lite")]
+    quantity: NotRequired[Annotated[int, "default: 1"]]
+
+
+SaladSize = Literal["half", "whole"]
+
+SaladStyle = Literal["Garden", "Greek"]
+
+
+class Salad(TypedDict):
+    itemType: Literal["Salad"]
+    portion: NotRequired[Annotated[str, "default: half"]]
+    style: NotRequired[Annotated[str, "default: Garden"]]
+    addedIngredients: NotRequired[Annotated[list[str], Doc("ingredients requested (examples: parmesan, croutons)")]]
+    removedIngredients: NotRequired[Annotated[list[str], Doc("ingredients requested to be removed (example: red onions)")]]
+    quantity: NotRequired[Annotated[int, "default: 1"]]
+
+
+OrderItem = Pizza | Beer | Salad
+
+
+class Order(TypedDict):
+    items: list[OrderItem | UnknownText]

--- a/python/examples/sentiment/demo.py
+++ b/python/examples/sentiment/demo.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import sys
+from dotenv import dotenv_values
+import schema as sentiment
+from typechat import Failure, TypeChatTranslator, TypeChatValidator, create_language_model
+
+
+async def main():
+    vals = dotenv_values()
+    model = create_language_model(vals)
+    validator = TypeChatValidator(sentiment.Sentiment)
+    translator = TypeChatTranslator(model, validator, sentiment.Sentiment)
+    print("😀> ", end="", flush=True)
+    for line in sys.stdin:
+        result = await translator.translate(line)
+        if isinstance(result, Failure):
+            print("Translation Failed ❌")
+            print(f"Context: {result.message}")
+        else:
+            result = result.value
+            print("Translation Succeeded! ✅\n")
+            print(f"The sentiment is {result['sentiment']}")
+        print("\n😀> ", end="", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/examples/sentiment/schema.py
+++ b/python/examples/sentiment/schema.py
@@ -1,0 +1,10 @@
+from typing import Literal, TypedDict, Annotated
+def Doc(s: str) -> str: return s
+
+
+class Sentiment(TypedDict):
+    """
+    The following is a schema definition for determining the sentiment of a some user input.
+    """
+
+    sentiment: Annotated[Literal["negative", "neutral", "positive"], Doc("The sentiment for the text")]

--- a/python/notebooks/calendar.ipynb
+++ b/python/notebooks/calendar.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade setuptools\n",
+    "!pip install --upgrade gradio\n",
+    "!pip install ipywidgets\n",
+    "!pip install openai\n",
+    "!pip install pandas\n",
+    "!pip install tabulate\n",
+    "!pip install python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -e ../"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import setuptools\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import dotenv_values\n",
+    "from typechat import Failure, TypeChatTranslator, TypeChatValidator, create_language_model\n",
+    "from examples.calendar import schema as calendar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = create_language_model(dotenv_values())\n",
+    "validator = TypeChatValidator(calendar.CalendarActions)\n",
+    "translator = TypeChatTranslator(model, validator, calendar.CalendarActions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "\n",
+    "async def get_translation(message, history):\n",
+    "    result = await translator.translate(message)\n",
+    "    if isinstance(result, Failure):\n",
+    "        return f\"Translation Failed ❌ \\n Context: {result.message}\"\n",
+    "    else:\n",
+    "        result = result.value\n",
+    "        df = pandas.DataFrame.from_dict(result[\"actions\"])\n",
+    "        return f\"Translation Succeeded! ✅\\n Table View \\n ``` {df.fillna('').to_markdown(tablefmt='grid')} \\n ```  \\n\"\n",
+    "\n",
+    "def get_examples():\n",
+    "    example_prompts = []\n",
+    "    with open('../../examples/calendar/src/input.txt') as prompts_file:\n",
+    "        for line in prompts_file:\n",
+    "            example_prompts.append(line)\n",
+    "    return example_prompts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on local URL:  http://127.0.0.1:7862\n",
+      "\n",
+      "To create a public link, set `share=True` in `launch()`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><iframe src=\"http://127.0.0.1:7862/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import gradio as gr\n",
+    "\n",
+    "gr.ChatInterface(get_translation, title=\"📅 Calendar\", examples=get_examples()).launch()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/notebooks/coffeeShop.ipynb
+++ b/python/notebooks/coffeeShop.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade setuptools\n",
+    "!pip install --upgrade gradio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "\n",
+    "import sys\n",
+    "from dotenv import dotenv_values\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)\n",
+    "\n",
+    "from examples.coffeeShop import schema as coffeeshop\n",
+    "from typechat import Failure, TypeChatTranslator, TypeChatValidator, create_language_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals = dotenv_values()\n",
+    "model = create_language_model(vals)\n",
+    "validator = TypeChatValidator(coffeeshop.Cart)\n",
+    "translator = TypeChatTranslator(model, validator, coffeeshop.Cart)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "async def get_translation(message, history):\n",
+    "    result = await translator.translate(message)\n",
+    "    if isinstance(result, Failure):\n",
+    "        return f\"Translation Failed ❌ \\n Context: {result.message}\"\n",
+    "    else:\n",
+    "        result = result.value\n",
+    "        df = pandas.DataFrame.from_dict(result[\"items\"])\n",
+    "        #return f\"Translation Succeeded! ✅\\n JSON View \\n ``` {json.dumps(result, indent=2)} \\n ``` \\n\"\n",
+    "        return f\"Translation Succeeded! ✅\\n Coffee Shop Items \\n ``` {df.fillna('').to_markdown(tablefmt='grid')} \\n ```  \\n\"\n",
+    "\n",
+    "def get_examples():\n",
+    "    example_prompts = []\n",
+    "    with open('../../examples/coffeeShop/src/input.txt') as prompts_file:\n",
+    "        for line in prompts_file:\n",
+    "            example_prompts.append(line)\n",
+    "    return example_prompts\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on local URL:  http://127.0.0.1:7915\n",
+      "\n",
+      "To create a public link, set `share=True` in `launch()`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><iframe src=\"http://127.0.0.1:7915/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import setuptools\n",
+    "import gradio as gr\n",
+    "\n",
+    "gr.ChatInterface(get_translation, title=\"☕ Coffee\", examples=get_examples()).launch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/notebooks/restaurant.ipynb
+++ b/python/notebooks/restaurant.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade setuptools\n",
+    "!pip install --upgrade gradio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import setuptools\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import dotenv_values\n",
+    "from typechat import Failure, TypeChatTranslator, TypeChatValidator, create_language_model\n",
+    "from examples.restaurant import schema as restaurant"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals = dotenv_values()\n",
+    "model = create_language_model(vals)\n",
+    "validator = TypeChatValidator(restaurant.Order)\n",
+    "translator = TypeChatTranslator(model, validator, restaurant.Order)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "async def get_translation(message, history):\n",
+    "    result = await translator.translate(message)\n",
+    "    if isinstance(result, Failure):\n",
+    "        return f\"Translation Failed ❌ \\n Context: {result.message}\"\n",
+    "    else:\n",
+    "        result = result.value\n",
+    "        df = pandas.DataFrame.from_dict(result[\"items\"])\n",
+    "        return f\"Translation Succeeded! ✅\\n Restaurant orders \\n ``` {df.fillna('').to_markdown(tablefmt='grid')} \\n ```  \\n\"\n",
+    "\n",
+    "\n",
+    "def get_examples():\n",
+    "    example_prompts = []\n",
+    "    with open('../../examples/restaurant/src/input.txt') as prompts_file:\n",
+    "        for line in prompts_file:\n",
+    "            example_prompts.append(line)\n",
+    "    return example_prompts\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on local URL:  http://127.0.0.1:7922\n",
+      "\n",
+      "To create a public link, set `share=True` in `launch()`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><iframe src=\"http://127.0.0.1:7922/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import gradio as gr\n",
+    "\n",
+    "gr.ChatInterface(get_translation, title=\"🍕 Restaurant\", examples=get_examples()).launch()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/notebooks/sentiment.ipynb
+++ b/python/notebooks/sentiment.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade setuptools\n",
+    "!pip install --upgrade gradio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "\n",
+    "import sys\n",
+    "from dotenv import dotenv_values\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)\n",
+    "\n",
+    "from examples.sentiment import schema as sentiment\n",
+    "from typechat import Failure, TypeChatTranslator, TypeChatValidator, create_language_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals = dotenv_values()\n",
+    "model = create_language_model(vals)\n",
+    "validator = TypeChatValidator(sentiment.Sentiment)\n",
+    "translator = TypeChatTranslator(model, validator, sentiment.Sentiment)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def get_translation(message, history):\n",
+    "    result = await translator.translate(message)\n",
+    "    if isinstance(result, Failure):\n",
+    "        return f\"Translation Failed ❌ \\n Context: {result.message}\"\n",
+    "    else:\n",
+    "        result = result.value\n",
+    "        return f\"Translation Succeeded! ✅\\n The sentiment is {result['sentiment']}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on local URL:  http://127.0.0.1:7921\n",
+      "\n",
+      "To create a public link, set `share=True` in `launch()`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><iframe src=\"http://127.0.0.1:7921/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import setuptools\n",
+    "import gradio as gr\n",
+    "\n",
+    "gr.ChatInterface(get_translation, title=\"😀 Sentiment\").launch()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This change adds examples that use straightforward schema translation: Sentiment, Restaurant and Calendar, Each example has a console demo as well as a jupyter notebook. The demos are ported from the typescript implementation of TypeChat.