### PR TITLE
Add support for translating dataclasses

### DIFF
--- a/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
+++ b/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
@@ -258,7 +258,9 @@ def python_type_to_typescript_nodes(root_py_type: object) -> TypeScriptNodeTrans
         while origin := get_origin(current_annotation):
             if origin is Annotated and comment is None:
                 current_annotation = cast(Annotatedish, current_annotation)
-                annotation_metadata = current_annotation.__metadata__[0]
+                all_supported_metadata = (m for m in current_annotation.__metadata__ if isinstance(m, (str, Doc)))
+                annotation_metadata = next(all_supported_metadata, None)
+                
                 if isinstance(annotation_metadata, Doc):
                     comment = annotation_metadata.documentation
                 elif isinstance(annotation_metadata, str):

--- a/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
+++ b/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
@@ -258,13 +258,14 @@ def python_type_to_typescript_nodes(root_py_type: object) -> TypeScriptNodeTrans
         while origin := get_origin(current_annotation):
             if origin is Annotated and comment is None:
                 current_annotation = cast(Annotatedish, current_annotation)
-                all_supported_metadata = (m for m in current_annotation.__metadata__ if isinstance(m, (str, Doc)))
-                annotation_metadata = next(all_supported_metadata, None)
-                
-                if isinstance(annotation_metadata, Doc):
-                    comment = annotation_metadata.documentation
-                elif isinstance(annotation_metadata, str):
-                    comment = annotation_metadata
+
+                for metadata in current_annotation.__metadata__:
+                    if isinstance(metadata, Doc):
+                        comment = metadata.documentation
+                        break
+                    if isinstance(metadata, str):
+                        comment = metadata
+                        break
 
                 current_annotation = current_annotation.__origin__
 

--- a/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
+++ b/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
@@ -270,10 +270,11 @@ def python_type_to_typescript_nodes(root_py_type: object) -> TypeScriptNodeTrans
                 if not is_typeddict_attribute:
                     errors.append(f"Optionality cannot be specified with {origin} outside of TypedDicts.")
 
-                if optional is not None:
+                if optional is None:
+                    optional = origin is NotRequired
+                else:
                     errors.append(f"{origin} cannot be used within another optionality annotation.")
 
-                optional = origin is NotRequired
                 current_annotation = get_args(current_annotation)[0]
             else:
                 break

--- a/python/tests/hello_dataclasses.py
+++ b/python/tests/hello_dataclasses.py
@@ -1,0 +1,37 @@
+
+from typing import Annotated
+from typechat import python_type_to_typescript_schema
+
+from dataclasses import dataclass, field
+
+@dataclass
+class Options:
+    """
+    TODO: someone add something here.
+    """
+    ...
+
+@dataclass
+class Response:
+    attr_1: str
+    attr_2: Annotated[int, "Hello!"]
+    attr_3: str | None
+    attr_4: str = "hello!"
+    attr_5: str | None = None
+    attr_6: list[str] = field(default_factory=list)
+    attr_7: Options = field(default_factory=Options)
+    _underscore_attr_1: int = 123
+
+    def do_something(self):
+        print(f"{self.attr_1=}")
+
+
+result = python_type_to_typescript_schema(Response)
+
+print(f"// Entry point is: '{result.typescript_type_reference}'")
+print("// TypeScript Schema:\n")
+print(result.typescript_schema_str)
+if result.errors:
+    print("// Errors:")
+    for err in result.errors:
+        print(f"// - {err}\n")

--- a/python/tests/hello_world.py
+++ b/python/tests/hello_world.py
@@ -15,7 +15,7 @@ type IndirectC = C[int]
 class D(C[str], total=False):
     "This is the definition of the class D."
     tag: Literal["D"]
-    y: Required[Annotated[bool | None, "This is a string."]]
+    y: Required[Annotated[bool | None, "This comes from string metadata\nwithin an Annotated hint."]]
     z: Optional[list[int]]
     other: IndirectC
     non_class: "nonclass"
@@ -38,7 +38,7 @@ type D_or_E = D | E
 
 result = python_type_to_typescript_schema(D_or_E)
 
-print("// Entry point is: '{result.typescript_type_reference}'")
+print(f"// Entry point is: '{result.typescript_type_reference}'")
 print("// TypeScript Schema:\n")
 print(result.typescript_schema_str)
 if result.errors:

--- a/python/tests/hello_world.py
+++ b/python/tests/hello_world.py
@@ -20,6 +20,7 @@ class D(C[str], total=False):
     other: IndirectC
     non_class: "nonclass"
 
+    multiple_metadata: Annotated[str, None, str, "This comes from later metadata.", int]
 
 nonclass = TypedDict("NonClass", {
     "a": int,


### PR DESCRIPTION
This change enables translation of dataclasses into TypeScript schemas. Using dataclasses allows developers to operate over actual Python objects - in contrast, if we took an approach where we only permitted `TypedDict`s, developers would be restricted to only operating over dictionaries. With this, schemas can be generated from one, the other, or a mix of both.

Fixes #160