### PR TITLE
Python: update implementation to use python 3.11

### DIFF
--- a/python/.devcontainer/DockerFile
+++ b/python/.devcontainer/DockerFile
@@ -1,3 +1,0 @@
-FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye
-
-RUN pip install hatch

--- a/python/.devcontainer/devcontainer.json
+++ b/python/.devcontainer/devcontainer.json
@@ -1,29 +1,29 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Python 3.11",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+    "name": "Python 3.11",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [7860,7861,7862,7863,7864,7865,7866,7867,7868,7869,7870],
-	
-	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"ms-python.python",
-				"ms-python.vscode-pylance"
-			],
-			"settings": {
-				"python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.11"
-			}
-		}
-	},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [7860,7861,7862,7863,7864,7865,7866,7867,7868,7869,7870],
+    
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.11"
+            }
+        }
+    },
 
-	"onCreateCommand": "pip install hatch",
-	"postCreateCommand": "hatch config set dirs.env.virtual .hatch; hatch config update;hatch env create"
+    "onCreateCommand": "pip install hatch",
+    "postCreateCommand": "hatch config set dirs.env.virtual .hatch; hatch config update;hatch env create"
 }

--- a/python/.devcontainer/devcontainer.json
+++ b/python/.devcontainer/devcontainer.json
@@ -3,8 +3,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	//"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
-	"dockerFile": "DockerFile",
+	"image": "mcr.microsoft.com/devcontainers/python:3.10-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -21,11 +20,12 @@
 	            "ms-python.vscode-pylance"
 	        ],
 	        "settings": {
-	            "python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.12"
+	            "python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.10"
 	        }
 	     }
          },
-
+	
+	"onCreateCommand": "pip install hatch",
 	"postCreateCommand": "hatch config set dirs.env.virtual .hatch; hatch config update;hatch env create"
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/python/.devcontainer/devcontainer.json
+++ b/python/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Python 3",
+	"name": "Python 3.11",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
 
@@ -10,24 +10,20 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [7860,7861,7862,7863,7864,7865,7866,7867,7868,7869,7870],
-
-
-	 // Configure tool-specific properties.
-	 "customizations": {
-	     "vscode": {
-	        "extensions": [
-	            "ms-python.python",
-	            "ms-python.vscode-pylance"
-	        ],
-	        "settings": {
-	            "python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.11"
-	        }
-	     }
-         },
 	
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance"
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.11"
+			}
+		}
+	},
+
 	"onCreateCommand": "pip install hatch",
 	"postCreateCommand": "hatch config set dirs.env.virtual .hatch; hatch config update;hatch env create"
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/python/.devcontainer/devcontainer.json
+++ b/python/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:3.10-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -20,7 +20,7 @@
 	            "ms-python.vscode-pylance"
 	        ],
 	        "settings": {
-	            "python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.10"
+	            "python.defaultInterpreterPath": "/workspaces/TypeChat/python/.hatch/typechat/bin/python3.11"
 	        }
 	     }
          },

--- a/python/examples/calendar/schema.py
+++ b/python/examples/calendar/schema.py
@@ -1,9 +1,5 @@
-from typing import Literal, NotRequired, TypedDict, Annotated
-
-
-def Doc(s: str) -> str:
-    return s
-
+from __future__ import annotations
+from typing_extensions import Literal, NotRequired, TypedDict, Annotated, Doc
 
 class UnknownAction(TypedDict):
     """

--- a/python/examples/calendar/schema.py
+++ b/python/examples/calendar/schema.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing_extensions import Literal, NotRequired, TypedDict, Annotated, Doc
 
 class UnknownAction(TypedDict):

--- a/python/examples/coffeeShop/schema.py
+++ b/python/examples/coffeeShop/schema.py
@@ -1,5 +1,4 @@
-from typing import Literal, NotRequired, TypedDict, Annotated
-def Doc(s: str) -> str: return s
+from typing_extensions import Literal, NotRequired, TypedDict, Annotated, Doc
 
 
 class UnknownText(TypedDict):

--- a/python/examples/healthData/schema.py
+++ b/python/examples/healthData/schema.py
@@ -1,8 +1,4 @@
-from typing import TypedDict, Annotated, NotRequired, Literal
-
-
-def Doc(s: str) -> str:
-    return s
+from typing_extensions import TypedDict, Annotated, NotRequired, Literal, Doc
 
 
 class Quantity(TypedDict):

--- a/python/examples/healthData/translator.py
+++ b/python/examples/healthData/translator.py
@@ -1,6 +1,6 @@
 import json
 from textwrap import dedent, indent
-from typing import TypeVar, Any, override, TypedDict, Literal
+from typing_extensions import TypeVar, Any, override, TypedDict, Literal
 
 from typechat import TypeChatValidator, TypeChatModel, TypeChatTranslator, Result, Failure
 

--- a/python/examples/math/program.py
+++ b/python/examples/math/program.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import asyncio
 import json
 from textwrap import dedent, indent
-from typing import TypeVar, Any, Callable, Awaitable, TypedDict, Annotated,  NotRequired, override, Sequence
+from typing_extensions import TypeVar, Any, Callable, Awaitable, TypedDict, Annotated,  NotRequired, override, Sequence, Doc
 
 from typechat import (
     Failure,
@@ -16,9 +16,6 @@ from typechat import (
 import collections.abc
 
 T = TypeVar("T", covariant=True)
-
-def Doc(s: str) -> str:
-    return s
 
 
 program_schema_text = '''

--- a/python/examples/math/schema.py
+++ b/python/examples/math/schema.py
@@ -1,8 +1,4 @@
-from typing import TypedDict, Annotated, Callable
-
-
-def Doc(s: str) -> str:
-    return s
+from typing_extensions import TypedDict, Annotated, Callable, Doc
 
 
 class MathAPI(TypedDict):

--- a/python/examples/math/schemaV2.py
+++ b/python/examples/math/schemaV2.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing_extensions import Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/python/examples/music/client.py
+++ b/python/examples/music/client.py
@@ -142,7 +142,7 @@ async def get_tracks_with_genres(
 def print_tracks(tracks: list[SimplifiedTrackInfo]):
     for track in tracks:
         print(f" {track.name}")
-        print(f"   Artists: {", ".join(track.artistNames)}")
+        print(f"   Artists: {', '.join(track.artistNames)}")
         print(f"   Album: {track.albumName}")
 
 
@@ -243,7 +243,7 @@ async def handle_call(action: PlayerAction, context: ClientContext):
             print("Current Queue: ")
             for track in queue["queue"]:
                 print(f" {track['name']}")
-                print(f"   Artists: {", ".join([a['name'] for a in track['artists']])}")
+                print(f"   Artists: {', '.join([a['name'] for a in track['artists']])}")
                 print(f"   Album: {track['album']['name']}")
             await print_status(context)
         case "pause":

--- a/python/examples/music/schema.py
+++ b/python/examples/music/schema.py
@@ -1,5 +1,4 @@
-from typing import Literal, Required, NotRequired, TypedDict, Annotated
-def Doc(s: str) -> str: return s
+from typing_extensions import Literal, Required, NotRequired, TypedDict, Annotated, Doc
 
 
 class unknownActionParameters(TypedDict):

--- a/python/examples/music/spotipyWrapper.py
+++ b/python/examples/music/spotipyWrapper.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing_extensions import Any, Optional
 from pydantic.dataclasses import dataclass
 import spotipy
 

--- a/python/examples/restaurant/schema.py
+++ b/python/examples/restaurant/schema.py
@@ -1,8 +1,4 @@
-from typing import Literal, Required, NotRequired, TypedDict, Annotated
-
-
-def Doc(s: str) -> str:
-    return s
+from typing_extensions import Literal, Required, NotRequired, TypedDict, Annotated, Doc
 
 
 class UnknownText(TypedDict):

--- a/python/examples/sentiment/schema.py
+++ b/python/examples/sentiment/schema.py
@@ -1,5 +1,4 @@
-from typing import Literal, TypedDict, Annotated
-def Doc(s: str) -> str: return s
+from typing_extensions import Literal, TypedDict, Annotated, Doc
 
 
 class Sentiment(TypedDict):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "typechat"
 dynamic = ["version"]
 description = 'TypeChat is a library that makes it easy to build natural language interfaces using types.'
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,7 +16,7 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -61,7 +61,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.10"]
+python = ["3.11"]
 
 [tool.hatch.envs.lint]
 detached = true
@@ -93,16 +93,16 @@ all = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 untyped_calls_exclude  = ["spotipy"]
 
 [tool.black]
-target-version = ["py310"]
+target-version = ["py311"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 120
 select = [
   "A",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "typechat"
 dynamic = ["version"]
 description = 'TypeChat is a library that makes it easy to build natural language interfaces using types.'
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,7 +16,7 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -41,6 +41,7 @@ dependencies = [
   "openai>=1.3.6",
   "python-dotenv>=1.0.0",
   "pytest",
+  "typing_extensions",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
@@ -60,7 +61,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.12"]
+python = ["3.10"]
 
 [tool.hatch.envs.lint]
 detached = true
@@ -92,16 +93,16 @@ all = [
 ]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.10"
 untyped_calls_exclude  = ["spotipy"]
 
 [tool.black]
-target-version = ["py312"]
+target-version = ["py310"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 120
 select = [
   "A",

--- a/python/pyrightconfig.json
+++ b/python/pyrightconfig.json
@@ -10,7 +10,7 @@
     "reportUninitializedInstanceVariable": "error",
     "reportUnnecessaryTypeIgnoreComment": "error",
     "reportUnusedCallResult": "none",
-    "pythonVersion": "3.12",
+    "pythonVersion": "3.10",
     "include": [
         "**/*",
     ],

--- a/python/pyrightconfig.json
+++ b/python/pyrightconfig.json
@@ -10,7 +10,7 @@
     "reportUninitializedInstanceVariable": "error",
     "reportUnnecessaryTypeIgnoreComment": "error",
     "reportUnusedCallResult": "none",
-    "pythonVersion": "3.10",
+    "pythonVersion": "3.11",
     "include": [
         "**/*",
     ],

--- a/python/src/typechat/_internal/model.py
+++ b/python/src/typechat/_internal/model.py
@@ -1,4 +1,4 @@
-from typing import Protocol, override
+from typing_extensions import Protocol, override
 import os
 import openai
 

--- a/python/src/typechat/_internal/result.py
+++ b/python/src/typechat/_internal/result.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing_extensions import Generic, TypeVar
 
 T = TypeVar("T", covariant=True)
 

--- a/python/src/typechat/_internal/translator.py
+++ b/python/src/typechat/_internal/translator.py
@@ -1,5 +1,5 @@
 from textwrap import dedent, indent
-from typing import Generic, TypeVar
+from typing_extensions import Generic, TypeVar
 
 from typechat._internal.model import TypeChatModel
 from typechat._internal.result import Failure, Result, Success

--- a/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
+++ b/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
@@ -239,19 +239,22 @@ def python_type_to_typescript_nodes(root_py_type: object) -> TypeScriptNodeTrans
         comments: str = ""
         while origin := get_origin(origin):
             if origin is Annotated and hasattr(py_annotation, "__metadata__"):
-                if isinstance(py_annotation.__metadata__[0], Doc):
-                    comments =  py_annotation.__metadata__[0].documentation
+                first_doc = next((x for x in py_annotation.__metadata__ if isinstance(x, Doc)), None)
+                if first_doc:
+                    comments =  first_doc.documentation
                 else:
-                    comments = py_annotation.__metadata__[0]
+                    comments = next((x for x in py_annotation.__metadata__ if isinstance(x, str)), "")
+
             elif origin in _KNOWN_GENERIC_SPECIAL_FORMS:
                 nested = get_args(py_annotation)
                 if nested:
                     nested_origin = get_origin(nested[0])
                     if nested_origin is Annotated:
-                        if isinstance(nested[0].__metadata__[0], Doc):
-                            comments = nested[0].__metadata__[0].documentation
+                        first_doc = next((x for x in nested[0].__metadata__ if isinstance(x, Doc)), None)
+                        if first_doc:
+                            comments =  first_doc.documentation
                         else:
-                            comments = nested[0].__metadata__[0]
+                            comments = next((x for x in nested[0].__metadata__ if isinstance(x, str)), "")
             if origin is Required:
                 optional = False
                 break

--- a/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
+++ b/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import typing
+import typing_extensions
 from dataclasses import dataclass
-from types import NoneType, UnionType, get_original_bases
-from typing import (
+from types import NoneType, UnionType
+from typing_extensions import (
     Annotated,
     Any,
     ClassVar,
+    Doc,
     Final,
     Generic,
     Literal,
@@ -25,6 +26,7 @@ from typing import (
     cast,
     get_args,
     get_origin,
+    get_original_bases,
     get_type_hints,
     is_typeddict,
 )
@@ -95,7 +97,7 @@ class TypeScriptNodeTranslationResult:
 
 
 # TODO: https://github.com/microsoft/pyright/issues/6587
-_SELF_TYPE = getattr(typing, "Self")
+_SELF_TYPE = getattr(typing_extensions, "Self")
 
 _LIST_TYPES: set[object] = {
     list,
@@ -237,13 +239,19 @@ def python_type_to_typescript_nodes(root_py_type: object) -> TypeScriptNodeTrans
         comments: str = ""
         while origin := get_origin(origin):
             if origin is Annotated and hasattr(py_annotation, "__metadata__"):
-                comments = py_annotation.__metadata__[0]
+                if isinstance(py_annotation.__metadata__[0], Doc):
+                    comments =  py_annotation.__metadata__[0].documentation
+                else:
+                    comments = py_annotation.__metadata__[0]
             elif origin in _KNOWN_GENERIC_SPECIAL_FORMS:
                 nested = get_args(py_annotation)
                 if nested:
                     nested_origin = get_origin(nested[0])
                     if nested_origin is Annotated:
-                        comments = nested[0].__metadata__[0]
+                        if isinstance(nested[0].__metadata__[0], Doc):
+                            comments = nested[0].__metadata__[0].documentation
+                        else:
+                            comments = nested[0].__metadata__[0]
             if origin is Required:
                 optional = False
                 break
@@ -256,7 +264,11 @@ def python_type_to_typescript_nodes(root_py_type: object) -> TypeScriptNodeTrans
     def declare_type(py_type: object):
         if is_typeddict(py_type):
             assert isinstance(py_type, type)
-            type_params = [TypeParameterDeclarationNode(type_param.__name__) for type_param in py_type.__type_params__]
+            if hasattr(py_type, "__type_params__"):
+                type_params = [TypeParameterDeclarationNode(type_param.__name__) for type_param in py_type.__type_params__]
+            else:
+                type_params = None
+
             annotated_members = get_type_hints(py_type, include_extras=True)
             assume_optional = cast(TypeOfTypedDict, py_type).__total__ is False
             raw_but_filtered_bases: list[type] = [

--- a/python/src/typechat/_internal/ts_conversion/ts_node_to_string.py
+++ b/python/src/typechat/_internal/ts_conversion/ts_node_to_string.py
@@ -1,5 +1,5 @@
 import json
-from typing import assert_never
+from typing_extensions import assert_never
 
 from typechat._internal.ts_conversion.ts_type_nodes import (
     ArrayTypeNode,

--- a/python/src/typechat/_internal/ts_conversion/ts_type_nodes.py
+++ b/python/src/typechat/_internal/ts_conversion/ts_type_nodes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing_extensions import TypeAlias
 
 TypeNode: TypeAlias = "TypeReferenceNode | UnionTypeNode | LiteralTypeNode | ArrayTypeNode"
 

--- a/python/src/typechat/_internal/validator.py
+++ b/python/src/typechat/_internal/validator.py
@@ -1,5 +1,5 @@
 import json
-from typing import Generic, TypeVar
+from typing_extensions import Generic, TypeVar
 
 import pydantic
 

--- a/python/tests/coffeeshop.py
+++ b/python/tests/coffeeshop.py
@@ -1,7 +1,6 @@
-from typing import Literal, NotRequired, TypedDict, Annotated
+from typing_extensions import Literal, NotRequired, TypedDict, Annotated, Doc
 
 from typechat import python_type_to_typescript_schema
-def Doc(s: str) -> str: return s
 
 
 class UnknownText(TypedDict):


### PR DESCRIPTION
This change updates the core implementation and the examples to run python 3.11
- Use typing_extensions package
- Adjust some syntax e.g. f-strings to align to 3.11
- Update project dependencies and the devcontainer definition