### PR TITLE
Update test cases to work on 3.11

### DIFF
--- a/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
+++ b/python/src/typechat/_internal/ts_conversion/python_type_to_ts_nodes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from types import NoneType, UnionType, get_original_bases
 import inspect
+import typing
 import typing_extensions
 from dataclasses import MISSING, Field, dataclass
 from types import NoneType, UnionType
@@ -20,8 +20,7 @@ from typing_extensions import (
     Protocol,
     Required,
     TypeAlias,
-    TypeAliasType,
-    TypedDict,
+    TypeAliasType,    
     TypeGuard,
     TypeVar,
     Union,
@@ -99,7 +98,7 @@ _KNOWN_GENERIC_SPECIAL_FORMS: frozenset[Any] = frozenset(
     ]
 )
 
-_KNOWN_SPECIAL_BASES: frozenset[Any] = frozenset([TypedDict, Protocol])
+_KNOWN_SPECIAL_BASES: frozenset[Any] = frozenset([typing.TypedDict, typing_extensions.TypedDict, Protocol])
 
 
 @dataclass

--- a/python/tests/generic_alias_1.py
+++ b/python/tests/generic_alias_1.py
@@ -1,18 +1,22 @@
-from typing import Literal, TypedDict
+from typing import Literal, TypedDict, TypeVar, Generic
+from typing_extensions import TypeAliasType
 
 from typechat import python_type_to_typescript_schema
 
-class First[T](TypedDict):
+T = TypeVar("T", covariant=True)
+
+
+class First(Generic[T], TypedDict):
     kind: Literal["first"]
     first_attr: T
 
 
-class Second[T](TypedDict):
+class Second(Generic[T], TypedDict):
     kind: Literal["second"]
     second_attr: T
 
 
-type FirstOrSecond[T] = First[T] | Second[T]
+FirstOrSecond = TypeAliasType("FirstOrSecond", First[T] | Second[T], type_params=(T,))
 
 result = python_type_to_typescript_schema(FirstOrSecond)
 

--- a/python/tests/generic_alias_2.py
+++ b/python/tests/generic_alias_2.py
@@ -1,19 +1,22 @@
-from typing import Literal, TypedDict
+from typing import Literal, TypedDict, Generic, TypeVar
 
 from typechat import python_type_to_typescript_schema
+from typing_extensions import TypeAliasType
+
+T = TypeVar("T", covariant=True)
 
 
-class First[T](TypedDict):
+class First(Generic[T], TypedDict):
     kind: Literal["first"]
     first_attr: T
 
 
-class Second[T](TypedDict):
+class Second(Generic[T], TypedDict):
     kind: Literal["second"]
     second_attr: T
 
 
-type FirstOrSecond[T] = First[T] | Second[T]
+FirstOrSecond = TypeAliasType("FirstOrSecond", First[T] | Second[T], type_params=(T,))
 
 
 class Nested(TypedDict):

--- a/python/tests/hello_world.py
+++ b/python/tests/hello_world.py
@@ -1,15 +1,17 @@
-from typing import Annotated, Literal, NotRequired, Optional, Required, Self, TypedDict
-
+from typing import Annotated, Literal, NotRequired, Optional, Required, Self, TypedDict, TypeVar, Generic
+from typing_extensions import TypeAliasType
 from typechat import python_type_to_typescript_schema
 
+T = TypeVar("T", covariant=True)
 
-class C[T](TypedDict):
+
+class C(Generic[T], TypedDict):
     "This is a generic class named C."
     x: NotRequired[T]
     c: "C[int | float | None]"
 
 
-type IndirectC = C[int]
+IndirectC = TypeAliasType("IndirectC", C[int])
 
 
 class D(C[str], total=False):
@@ -22,10 +24,8 @@ class D(C[str], total=False):
 
     multiple_metadata: Annotated[str, None, str, "This comes from later metadata.", int]
 
-nonclass = TypedDict("NonClass", {
-    "a": int,
-    "my-dict": dict[str, int]
-})
+
+nonclass = TypedDict("NonClass", {"a": int, "my-dict": dict[str, int]})
 
 
 class E(C[str]):
@@ -34,7 +34,7 @@ class E(C[str]):
     next: Self | None
 
 
-type D_or_E = D | E
+D_or_E = TypeAliasType("D_or_E", D | E)
 
 
 result = python_type_to_typescript_schema(D_or_E)


### PR DESCRIPTION
- use the pre-3.11 approach for declaring generic classes and typealiastype
- check for both typing.TypedDict and typing_extensions.TypedDict in _KNOWN_SPECIAL_BASES
