### PR TITLE
Python housekeeping

### DIFF
--- a/python/examples/math/demo.py
+++ b/python/examples/math/demo.py
@@ -1,10 +1,12 @@
 import asyncio
+from collections.abc import Sequence
 import json
 import sys
+from typing import cast
 from dotenv import dotenv_values
 import schema as math
 from typechat import Failure, create_language_model, process_requests
-from program import TypeChatProgramTranslator, TypeChatProgramValidator, JsonProgram, evaluate_json_program  # type: ignore
+from program import TypeChatProgramTranslator, TypeChatProgramValidator, JsonProgram, evaluate_json_program
 
 vals = dotenv_values()
 model = create_language_model(vals)
@@ -12,8 +14,15 @@ validator = TypeChatProgramValidator(JsonProgram)
 translator = TypeChatProgramTranslator(model, validator, math.MathAPI)
 
 
-async def apply_operations(func: str, args: list[int | float]) -> int | float:
+async def apply_operations(func: str, args: Sequence[object]) -> int | float:
     print(f"{func}({json.dumps(args)}) ")
+
+    for arg in args:
+        if not isinstance(arg, (int, float)):
+            raise ValueError("All arguments are expected to be numeric.")
+
+    args = cast(Sequence[int | float], args)
+
     match func:
         case "add":
             return args[0] + args[1]
@@ -38,7 +47,7 @@ async def request_handler(message: str):
     else:
         result = result.value
         print(json.dumps(result, indent=2))
-        math_result = await evaluate_json_program(result, apply_operations)  # type: ignore
+        math_result = await evaluate_json_program(result, apply_operations)
         print(f"Math Result: {math_result}")
 
 

--- a/python/examples/math/demo.py
+++ b/python/examples/math/demo.py
@@ -6,11 +6,11 @@ from typing import cast
 from dotenv import dotenv_values
 import schema as math
 from typechat import Failure, create_language_model, process_requests
-from program import TypeChatProgramTranslator, TypeChatProgramValidator, JsonProgram, evaluate_json_program
+from program import TypeChatProgramTranslator, TypeChatProgramValidator, evaluate_json_program
 
 vals = dotenv_values()
 model = create_language_model(vals)
-validator = TypeChatProgramValidator(JsonProgram)
+validator = TypeChatProgramValidator()
 translator = TypeChatProgramTranslator(model, validator, math.MathAPI)
 
 

--- a/python/examples/math/program.py
+++ b/python/examples/math/program.py
@@ -125,17 +125,17 @@ async def evaluate_json_program(
         return None
 
 
-class TypeChatProgramValidator(TypeChatValidator[T]):
+class TypeChatProgramValidator(TypeChatValidator[JsonProgram]):
     def __init__(self):
         # TODO: This example should eventually be updated to use Python 3.12 type aliases
         # Passing in `JsonProgram` for `py_type` would cause issues because
         # Pydantic's `TypeAdapter` ends up trying to eagerly construct an
         # anonymous recursive type. Even a NewType does not work here.
-        # For now, we just 
-        super().__init__(py_type=Any)
+        # For now, we just pass in `Any` in place of `JsonProgram`.
+        super().__init__(py_type=cast(type[JsonProgram], Any))
 
     @override
-    def validate(self, json_text: str) -> Result[T]:
+    def validate(self, json_text: str) -> Result[JsonProgram]:
         # Pydantic is not able to validate JsonProgram instances. It fails with a recursion error.
         # For JsonProgram, so we simply validate that it has a non-zero number of `@steps`.
         # TODO: extend validations
@@ -146,10 +146,10 @@ class TypeChatProgramValidator(TypeChatValidator[T]):
             return Failure("This is not a valid program. The program must have an array of @steps")
 
 
-class TypeChatProgramTranslator(TypeChatTranslator[T]):
+class TypeChatProgramTranslator(TypeChatTranslator[JsonProgram]):
     _api_declaration_str: str
 
-    def __init__(self, model: TypeChatModel, validator: TypeChatProgramValidator[T], api_type: type):
+    def __init__(self, model: TypeChatModel, validator: TypeChatProgramValidator, api_type: type):
         super().__init__(model=model, validator=validator, target_type=api_type)
         # TODO: the conversion result here has errors!
         conversion_result = python_type_to_typescript_schema(api_type)

--- a/python/examples/math/program.py
+++ b/python/examples/math/program.py
@@ -79,7 +79,7 @@ async def evaluate_json_program(
 ) -> Expression:
     results: list[JsonValue] = []
 
-    def evaluate_array(array: list[Expression]) -> Awaitable[list[Expression]]:
+    def evaluate_array(array: Sequence[Expression]) -> Awaitable[list[Expression]]:
         return asyncio.gather(*[evaluate_expression(e) for e in array])
 
     async def evaluate_expression(expr: Expression) -> JsonValue:

--- a/python/examples/multiSchema/agents.py
+++ b/python/examples/multiSchema/agents.py
@@ -50,7 +50,7 @@ class MathAgent:
 
     def __init__(self, model: TypeChatModel):
         super().__init__()
-        self._validator = TypeChatProgramValidator(JsonProgram)
+        self._validator = TypeChatProgramValidator()
         self._translator = TypeChatProgramTranslator(model, self._validator, math_schema.MathAPI)
 
     async def _handle_json_program_call(self, func: str, args: Sequence[object]) -> int | float:

--- a/python/examples/multiSchema/agents.py
+++ b/python/examples/multiSchema/agents.py
@@ -1,5 +1,7 @@
+from collections.abc import Sequence
 import os
 import sys
+from typing import cast
 
 examples_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if examples_path not in sys.path:
@@ -14,7 +16,7 @@ import examples.math.schema as math_schema
 from examples.math.program import (
     TypeChatProgramTranslator,
     TypeChatProgramValidator,
-    evaluate_json_program,  # type: ignore
+    evaluate_json_program,
     JsonProgram,
 )
 
@@ -51,8 +53,15 @@ class MathAgent:
         self._validator = TypeChatProgramValidator(JsonProgram)
         self._translator = TypeChatProgramTranslator(model, self._validator, math_schema.MathAPI)
 
-    async def _handle_json_program_call(self, func: str, args: list[int | float]) -> int | float:
+    async def _handle_json_program_call(self, func: str, args: Sequence[object]) -> int | float:
         print(f"{func}({json.dumps(args)}) ")
+        
+        for arg in args:
+            if not isinstance(arg, (int, float)):
+                raise ValueError("All arguments are expected to be numeric.")
+
+        args = cast(Sequence[int | float], args)
+
         match func:
             case "add":
                 return args[0] + args[1]

--- a/python/examples/multiSchema/agents.py
+++ b/python/examples/multiSchema/agents.py
@@ -17,7 +17,6 @@ from examples.math.program import (
     TypeChatProgramTranslator,
     TypeChatProgramValidator,
     evaluate_json_program,
-    JsonProgram,
 )
 
 import examples.music.schema as music_schema
@@ -45,8 +44,8 @@ class JsonPrintAgent(Generic[T]):
 
 
 class MathAgent:
-    _validator: TypeChatProgramValidator[JsonProgram]
-    _translator: TypeChatProgramTranslator[JsonProgram]
+    _validator: TypeChatProgramValidator
+    _translator: TypeChatProgramTranslator
 
     def __init__(self, model: TypeChatModel):
         super().__init__()

--- a/python/examples/music/spotipyWrapper.py
+++ b/python/examples/music/spotipyWrapper.py
@@ -1,6 +1,6 @@
 from typing_extensions import Any
 from pydantic.dataclasses import dataclass, field
-import spotipy
+import spotipy # type: ignore
 
 # The spotipy library does not provide type hints or async methods. This file has some wrappers and stubs 
 # to give just-enough typing for the demo

--- a/python/examples/music/spotipyWrapper.py
+++ b/python/examples/music/spotipyWrapper.py
@@ -1,6 +1,6 @@
 from typing_extensions import Any
 from pydantic.dataclasses import dataclass, field
-import spotipy # type: ignore
+import spotipy
 
 # The spotipy library does not provide type hints or async methods. This file has some wrappers and stubs 
 # to give just-enough typing for the demo

--- a/python/notebooks/math.ipynb
+++ b/python/notebooks/math.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "from dotenv import dotenv_values\n",
     "from typechat import Failure, create_language_model\n",
-    "from examples.math.program import TypeChatProgramTranslator, TypeChatProgramValidator, JsonProgram, evaluate_json_program\n",
+    "from examples.math.program import TypeChatProgramTranslator, TypeChatProgramValidator, evaluate_json_program\n",
     "from examples.math import schema as math"
    ]
   },
@@ -46,7 +46,7 @@
    "source": [
     "vals = dotenv_values()\n",
     "model = create_language_model(vals)\n",
-    "validator = TypeChatProgramValidator(JsonProgram)\n",
+    "validator = TypeChatProgramValidator()\n",
     "translator = TypeChatProgramTranslator(model, validator, math.MathAPI)"
    ]
   },

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,8 +41,10 @@ dependencies = [
   "openai>=1.3.6",
   "python-dotenv>=1.0.0",
   "pytest",
+  "spotipy", # for examples
   "typing_extensions",
 ]
+
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
@@ -53,11 +55,6 @@ cov-report = [
 cov = [
   "test-cov",
   "cov-report",
-]
-
-[tool.hatch.envs.examples]
-extra-dependencies = [
-  "spotipy",
 ]
 
 [[tool.hatch.envs.all.matrix]]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/python/src/typechat/__about__.py
+++ b/python/src/typechat/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Microsoft Corporation
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.1"
+__version__ = "0.0.2"

--- a/python/src/typechat/__init__.py
+++ b/python/src/typechat/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typechat._internal.model import DefaultOpenAIModel, TypeChatModel, create_language_model
+from typechat._internal.model import TypeChatModel, create_language_model
 from typechat._internal.result import Failure, Result, Success
 from typechat._internal.translator import TypeChatTranslator
 from typechat._internal.ts_conversion import python_type_to_typescript_schema

--- a/python/src/typechat/__init__.py
+++ b/python/src/typechat/__init__.py
@@ -10,7 +10,6 @@ from typechat._internal.validator import TypeChatValidator
 from typechat._internal.interactive import process_requests
 
 __all__ = [
-    "DefaultOpenAIModel",
     "TypeChatModel",
     "TypeChatTranslator",
     "TypeChatValidator",

--- a/python/src/typechat/_internal/interactive.py
+++ b/python/src/typechat/_internal/interactive.py
@@ -13,7 +13,7 @@ async def process_requests(interactive_prompt: str, input_file_name: str | None,
     else:
         print(interactive_prompt, end="", flush=True)
         for line in sys.stdin:
-            lower_line = line.lower()
+            lower_line = line.lower().strip()
             if lower_line == "quit" or lower_line == "exit":
                 break
             else:

--- a/python/src/typechat/_internal/model.py
+++ b/python/src/typechat/_internal/model.py
@@ -35,19 +35,23 @@ class DefaultOpenAIModel(TypeChatModel):
             return Failure(str(e))
 
 def create_language_model(vals: dict[str,str|None]) -> TypeChatModel:
-    model:TypeChatModel
+    model: TypeChatModel
     client: openai.AsyncOpenAI | openai.AsyncAzureOpenAI
-    
+
     if "OPENAI_API_KEY" in vals:
         client = openai.AsyncOpenAI(api_key=vals["OPENAI_API_KEY"])
         model = DefaultOpenAIModel(model_name=vals.get("OPENAI_MODEL", None) or "gpt-35-turbo", client=client)
 
     elif "AZURE_OPENAI_API_KEY" in vals and "AZURE_OPENAI_ENDPOINT" in vals:
         os.environ["OPENAI_API_TYPE"] = "azure"
-        client=openai.AsyncAzureOpenAI(azure_endpoint=vals.get("AZURE_OPENAI_ENDPOINT",None) or "", api_key=vals["AZURE_OPENAI_API_KEY"],api_version="2023-03-15-preview")
+        client = openai.AsyncAzureOpenAI(
+            azure_endpoint=vals.get("AZURE_OPENAI_ENDPOINT", None) or "",
+            api_key=vals["AZURE_OPENAI_API_KEY"],
+            api_version="2023-03-15-preview",
+        )
         model = DefaultOpenAIModel(model_name=vals.get("AZURE_OPENAI_MODEL", None) or "gpt-35-turbo", client=client)
-    
+
     else:
         raise ValueError("Missing environment variables for Open AI or Azure OpenAI model")
-        
+
     return model


### PR DESCRIPTION
This PR makes the following changes

* Further readies the repository for the upcoming release.
  * Set version to 0.0.2 (0.0.1 is already out)
  * Update the classifiers list
* Removes many `# type: ignore` comments and `@no_type_check` decorators (apart from the ones in `music`)
* Removes all unmasked type errors.
* Hides the `DefaultOpenAIModel` class in favor of just exposing `create_language_model`.
* Corrects the `process_requests` function to correctly handle `quit` and `exit` input (each line contains a trailing newline)
* Simplifies the evaluator in the `math` example.

I didn't spend much time on the music sample - there's a lot of type suppressions there and that probably needs its own PR.

I spent a decent amount of time replumbing the `math` example - and eventually realized there were a lot of surprising issues. For one, the TS schema translation has errors, and the signatures are translated to `Callable<any, number>`! That's because `Callable` isn't supported, and TypeChat doesn't translate tuples yet. On top of that, the reason Pydantic can't deal with `JsonProgram` is due to the lack of indirection in the union type - something that Python 3.12's type aliases would give us. If we were able to state that the example only works in Python 3.12, I think we could clean it up a lot and get real validation working there.