### PR TITLE
Add missing step in readme

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -28,7 +28,8 @@ You can also build TypeChat from source:
 
 ```
 git clone https://github.com/microsoft/TypeChat
-cd typescript/TypeChat
+cd TypeChat/typescript
+npm install
 npm run build
 ```
 


### PR DESCRIPTION
- Fix error in the path to the typescript edition of typechat
- Add step to npm install before npm build