### PR TITLE
Add CI for Python

### DIFF
--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -1,0 +1,57 @@
+name: Python CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./python
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - '3.11'
+          - '3.12'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Set up Hatch Environment
+        run: |
+          hatch env create
+          echo "$(hatch env find)/bin" >> $GITHUB_PATH
+
+      - name: Get Pyright Version
+        id: pyright-version
+        run: |
+          PYRIGHT_VERSION=$(jq -r '.devDependencies.pyright' < package.json)
+          echo $PYRIGHT_VERSION
+          echo "version=$PYRIGHT_VERSION" >> $GITHUB_OUTPUT
+
+      - uses: jakebailey/pyright-action@v2
+        with:
+          version: ${{ steps.pyright-version.outputs.version }}
+          no-comments: ${{ matrix.python-version != '3.12' || matrix.os != 'ubuntu-latest' }} # Only let one build post comments.

--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Set up Hatch Environment
         run: |
           hatch env create
-          echo "$(hatch env find)/bin" >> $GITHUB_PATH
+          HATCH_ENV=$(hatch env find)
+          echo $HATCH_ENV
+          echo "$HATCH_ENV/bin" >> $GITHUB_PATH
 
       - name: Get Pyright Version
         id: pyright-version
@@ -51,7 +53,8 @@ jobs:
           echo $PYRIGHT_VERSION
           echo "version=$PYRIGHT_VERSION" >> $GITHUB_OUTPUT
 
-      - uses: jakebailey/pyright-action@v2
+      - name: Run pyright ${{ steps.pyright-version.outputs.version }}
+        uses: jakebailey/pyright-action@v2
         with:
           version: ${{ steps.pyright-version.outputs.version }}
           no-comments: ${{ matrix.python-version != '3.12' || matrix.os != 'ubuntu-latest' }} # Only let one build post comments.

--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -14,7 +14,7 @@ defaults:
     working-directory: ./python
 
 jobs:
-  test:
+  pyright:
     strategy:
       fail-fast: false
       matrix:

--- a/python/package-lock.json
+++ b/python/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "pyright": "^1.1.341"
+        "pyright": "1.1.341"
       }
     },
     "node_modules/fsevents": {

--- a/python/package.json
+++ b/python/package.json
@@ -9,6 +9,6 @@
   "author": "Microsoft",
   "license": "MIT",
   "devDependencies": {
-    "pyright": "^1.1.341"
+    "pyright": "1.1.341"
   }
 }


### PR DESCRIPTION
This adds a CI workflow for checking the python directory.

This is not too dissimilar to https://github.com/python/typeshed/blob/main/.github/workflows/tests.yml or the docs at https://github.com/jakebailey/pyright-action.