### PR TITLE
Unpin Python version so that CI can check across versions.

### DIFF
--- a/python/pyrightconfig.json
+++ b/python/pyrightconfig.json
@@ -10,7 +10,6 @@
     "reportUninitializedInstanceVariable": "error",
     "reportUnnecessaryTypeIgnoreComment": "error",
     "reportUnusedCallResult": "none",
-    "pythonVersion": "3.11",
     "include": [
         "**/*",
     ],


### PR DESCRIPTION
Unfortunately this is a flag that is supported but nobody is expected set it normally, and no program can control it externally. See more at https://github.com/microsoft/pyright/issues/7330.