### PR TITLE
Replace usage of OpenAI SDK with direct API calls via httpx.

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "pydantic>=2.5.2",
+  "httpx>=0.27.0",
 ]
 
 [project.urls]
@@ -39,7 +40,6 @@ virtual = ".hatch"
 [tool.hatch.envs.default]
 dependencies = [
   "coverage[toml]>=6.5",
-  "openai>=1.3.6",
   "python-dotenv>=1.0.0",
   "pytest",
   "spotipy", # for examples

--- a/python/src/typechat/_internal/model.py
+++ b/python/src/typechat/_internal/model.py
@@ -1,11 +1,10 @@
 import asyncio
 from types import TracebackType
-from typing_extensions import AsyncContextManager, Literal, Protocol, Self, TypedDict, cast
-
-import httpx
+from typing_extensions import AsyncContextManager, Literal, Protocol, Self, TypedDict, cast, override
 
 from typechat._internal.result import Failure, Result, Success
 
+import httpx
 
 class TypeChatLanguageModel(Protocol):
     async def complete(self, prompt: str) -> Result[str]:
@@ -50,6 +49,7 @@ class HttpxLanguageModel(TypeChatLanguageModel, AsyncContextManager):
         self.default_params = default_params
         self._async_client = httpx.AsyncClient()
 
+    @override
     async def complete(self, prompt: str) -> Success[str] | Failure:
         headers = {
             "Content-Type": "application/json",

--- a/python/src/typechat/_internal/model.py
+++ b/python/src/typechat/_internal/model.py
@@ -44,6 +44,7 @@ class HttpxLanguageModel(TypeChatLanguageModel, AsyncContextManager):
     _retry_pause_seconds: float = 1.0
 
     def __init__(self, url: str, headers: dict[str, str], default_params: dict[str, str]):
+        super().__init__()
         self.url = url
         self.headers = headers
         self.default_params = default_params
@@ -86,9 +87,11 @@ class HttpxLanguageModel(TypeChatLanguageModel, AsyncContextManager):
             await asyncio.sleep(self._retry_pause_seconds)
             retry_count += 1
 
+    @override
     async def __aenter__(self) -> Self:
         return self
 
+    @override
     async def __aexit__(self, __exc_type: type[BaseException] | None, __exc_value: BaseException | None, __traceback: TracebackType | None) -> bool | None:
         await self._async_client.aclose()
 

--- a/python/src/typechat/_internal/model.py
+++ b/python/src/typechat/_internal/model.py
@@ -1,11 +1,14 @@
-from typing_extensions import Protocol, override
-import openai
+import asyncio
+from types import TracebackType
+from typing_extensions import AsyncContextManager, Literal, Protocol, Self, TypedDict, cast
+
+import httpx
 
 from typechat._internal.result import Failure, Result, Success
 
 
 class TypeChatLanguageModel(Protocol):
-    async def complete(self, input: str) -> Result[str]:
+    async def complete(self, prompt: str) -> Result[str]:
         """
         Represents a AI language model that can complete prompts.
         
@@ -16,30 +19,84 @@ class TypeChatLanguageModel(Protocol):
         """
         ...
 
+class _PromptSection(TypedDict):
+    """
+    Represents a section of an LLM prompt with an associated role. TypeChat uses the "user" role for
+    prompts it generates and the "assistant" role for previous LLM responses (which will be part of
+    the prompt in repair attempts). TypeChat currently doesn't use the "system" role.
+    """
+    role: Literal["system", "user", "assistant"]
+    content: str
 
-class DefaultOpenAIModel(TypeChatLanguageModel):
-    model_name: str
-    client: openai.AsyncOpenAI | openai.AsyncAzureOpenAI
+_TRANSIENT_ERROR_CODES = [
+    429,
+    500,
+    502,
+    503,
+    504,
+]
 
-    def __init__(self, model_name: str, client: openai.AsyncOpenAI | openai.AsyncAzureOpenAI):
-        super().__init__()
-        self.model_name = model_name
-        self.client = client
+class HttpxLanguageModel(TypeChatLanguageModel, AsyncContextManager):
+    url: str
+    headers: dict[str, str]
+    default_params: dict[str, str]
+    _async_client: httpx.AsyncClient
+    _max_retry_attempts: int = 3
+    _retry_pause_seconds: float = 1.0
 
-    @override
-    async def complete(self, input: str) -> Result[str]:
+    def __init__(self, url: str, headers: dict[str, str], default_params: dict[str, str]):
+        self.url = url
+        self.headers = headers
+        self.default_params = default_params
+        self._async_client = httpx.AsyncClient()
+
+    async def complete(self, prompt: str) -> Success[str] | Failure:
+        headers = {
+            "Content-Type": "application/json",
+            **self.headers,
+        }
+        messages = [{"role": "user", "content": prompt}]
+        body = {
+            **self.default_params,
+            "messages": messages,
+            "temperature": 0.0,
+            "n": 1,
+        }
+        retry_count = 0
+        while True:
+            try:
+                response = await self._async_client.post(
+                    self.url,
+                    headers=headers,
+                    json=body,
+                )
+                if response.is_success:
+                    json_result = cast(
+                        dict[Literal["choices"], list[dict[Literal["message"], _PromptSection]]],
+                        response.json()
+                    )
+                    return Success(json_result["choices"][0]["message"]["content"] or "")
+
+                if response.status_code not in _TRANSIENT_ERROR_CODES or retry_count >= self._max_retry_attempts:
+                    return Failure(f"REST API error {response.status_code}: {response.reason_phrase}")
+            except Exception as e:
+                if retry_count >= self._max_retry_attempts:
+                    return Failure(str(e))
+
+            await asyncio.sleep(self._retry_pause_seconds)
+            retry_count += 1
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, __exc_type: type[BaseException] | None, __exc_value: BaseException | None, __traceback: TracebackType | None) -> bool | None:
+        await self._async_client.aclose()
+
+    def __del__(self):
         try:
-            response = await self.client.chat.completions.create(
-                model=self.model_name,
-                messages=[{"role": "user", "content": input}],
-                temperature=0.0,
-            )
-            content = response.choices[0].message.content
-            if content is None:
-                return Failure("Response did not contain any text.")
-            return Success(content)
-        except Exception as e:
-            return Failure(str(e))
+            asyncio.get_running_loop().create_task(self._async_client.aclose())
+        except Exception:
+            pass
 
 def create_language_model(vals: dict[str, str | None]) -> TypeChatLanguageModel:
     """
@@ -58,9 +115,7 @@ def create_language_model(vals: dict[str, str | None]) -> TypeChatLanguageModel:
     Args:
         vals: A dictionary of variables. Typically just `os.environ`.
     """
-    model: TypeChatLanguageModel
-    client: openai.AsyncOpenAI | openai.AsyncAzureOpenAI
-
+    
     def required_var(name: str) -> str:
         val = vals.get(name, None)
         if val is None:
@@ -68,19 +123,50 @@ def create_language_model(vals: dict[str, str | None]) -> TypeChatLanguageModel:
         return val
 
     if "OPENAI_API_KEY" in vals:
-        client = openai.AsyncOpenAI(api_key=required_var("OPENAI_API_KEY"))
-        model = DefaultOpenAIModel(model_name=required_var("OPENAI_MODEL"), client=client)
+        api_key = required_var("OPENAI_API_KEY")
+        model = required_var("OPENAI_MODEL")
+        endpoint = vals.get("OPENAI_ENDPOINT", None) or "https://api.openai.com/v1/chat/completions"
+        org = vals.get("OPENAI_ORG", None) or ""
+        return create_openai_language_model(api_key, model, endpoint, org)
 
     elif "AZURE_OPENAI_API_KEY" in vals:
-        openai.api_type = "azure"
-        client = openai.AsyncAzureOpenAI(
-            api_key=required_var("AZURE_OPENAI_API_KEY"),
-            azure_endpoint=required_var("AZURE_OPENAI_ENDPOINT"),
-            api_version="2023-03-15-preview",
-        )
-        model = DefaultOpenAIModel(model_name=vals.get("AZURE_OPENAI_MODEL", None) or "gpt-35-turbo", client=client)
-
+        api_key=required_var("AZURE_OPENAI_API_KEY")
+        endpoint=required_var("AZURE_OPENAI_ENDPOINT")
+        return create_azure_openai_language_model(api_key, endpoint)
     else:
         raise ValueError("Missing environment variables for OPENAI_API_KEY or AZURE_OPENAI_API_KEY.")
 
-    return model
+def create_openai_language_model(api_key: str, model: str, endpoint: str = "https://api.openai.com/v1/chat/completions", org: str = ""):
+    """
+    Creates a language model encapsulation of an OpenAI REST API endpoint.
+
+    Args:
+        api_key: The OpenAI API key.
+        model: The OpenAI model name.
+        endpoint: The OpenAI REST API endpoint.
+        org: The OpenAI organization.
+    """
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "OpenAI-Organization": org,
+    }
+    default_params = {
+        "model": model,
+    }
+    return HttpxLanguageModel(url=endpoint, headers=headers, default_params=default_params)
+
+def create_azure_openai_language_model(api_key: str, endpoint: str):
+    """
+    Creates a language model encapsulation of an Azure OpenAI REST API endpoint.
+
+    Args:
+        api_key: The Azure OpenAI API key.
+        endpoint: The Azure OpenAI REST API endpoint.
+    """
+    headers = {
+        # Needed when using managed identity
+        "Authorization": f"Bearer {api_key}",
+        # Needed when using regular API key
+        "api-key": api_key,
+    }
+    return HttpxLanguageModel(url=endpoint, headers=headers, default_params={})


### PR DESCRIPTION
This change aligns the behavior of TypeChat for Python with that of its TypeScript counterpart with respect to Azure OpenAI usage.

While TypeChat for TypeScript simply accepted the fully-formed endpoint URL for chat completions [as documented here](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions), the `openai` package made it so that individual components of that URL had to be threaded through piecemeal (i.e. the deployment name, the model name, the version number, and the API key). What that meant was (at least as far as I could tell), the logic didn't work for Azure OpenAI.

This PR makes it so that TypeChat only cares about the API key and the fully formed URL being placed in your `.env` file:

```
AZURE_OPENAI_API_KEY={your-api-key}
AZURE_OPENAI_ENDPOINT=https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}
```