### PR TITLE
Python CI fixups

### DIFF
--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -58,5 +58,5 @@ jobs:
         with:
           version: ${{ steps.pyright-version.outputs.version }}
           python-version: ${{ matrix.python-version}}
-          annotate: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' }} # Only let one build post comments.
+          annotate: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' }} # Only let one build post comments.
           working-directory: ./python

--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -57,5 +57,6 @@ jobs:
         uses: jakebailey/pyright-action@v2
         with:
           version: ${{ steps.pyright-version.outputs.version }}
+          python-version: ${{ matrix.python-version}}
           annotate: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' }} # Only let one build post comments.
           working-directory: ./python

--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -57,5 +57,5 @@ jobs:
         uses: jakebailey/pyright-action@v2
         with:
           version: ${{ steps.pyright-version.outputs.version }}
-          no-comments: ${{ matrix.python-version != '3.12' || matrix.os != 'ubuntu-latest' }} # Only let one build post comments.
+          annotate: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' }} # Only let one build post comments.
           working-directory: ./python

--- a/python/package-lock.json
+++ b/python/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "pyright": "1.1.351"
+        "pyright": "1.1.352"
       }
     },
     "node_modules/fsevents": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/pyright": {
-      "version": "1.1.351",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.351.tgz",
-      "integrity": "sha512-z+E1II+8H6GRweHf06gRpvjEu1HQtQWZxTs8Zr9pATe79YOFByn8nSBc+iY/EAW+oXPtZEr7NU/9Fxa4fzXv6g==",
+      "version": "1.1.352",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.352.tgz",
+      "integrity": "sha512-X7fuuB24n3RIVCEPovrAadYJjxeB5RccArug+/oLwQnsHbSaDUQVHHkF/PJHkKpaIPX/RboG+EW8uCNUp1RnwQ==",
       "dev": true,
       "bin": {
         "pyright": "index.js",

--- a/python/package.json
+++ b/python/package.json
@@ -9,6 +9,6 @@
   "author": "Microsoft",
   "license": "MIT",
   "devDependencies": {
-    "pyright": "1.1.351"
+    "pyright": "1.1.352"
   }
 }

--- a/python/pyrightconfig.json
+++ b/python/pyrightconfig.json
@@ -10,6 +10,7 @@
     "reportUninitializedInstanceVariable": "error",
     "reportUnnecessaryTypeIgnoreComment": "error",
     "reportUnusedCallResult": "none",
+    "pythonVersion": "3.11",
     "include": [
         "**/*",
     ],

--- a/python/src/typechat/__init__.py
+++ b/python/src/typechat/__init__.py
@@ -20,5 +20,3 @@ __all__ = [
     "create_language_model",
     "process_requests"
 ]
-
-type Test = int

--- a/python/src/typechat/__init__.py
+++ b/python/src/typechat/__init__.py
@@ -20,3 +20,5 @@ __all__ = [
     "create_language_model",
     "process_requests"
 ]
+
+type Test = int


### PR DESCRIPTION
Updates CI to use `annotate` instead of `no-comments` (https://github.com/jakebailey/pyright-action/commit/93a05d0fa01403810a642a4d49bca4aac45a76b3)

Updates Pyright to the latest version and adds back the `pythonVersion` setting (see https://github.com/microsoft/TypeChat/pull/195 and https://github.com/microsoft/pyright/issues/7330).