### PR TITLE
Raise when TypeScript schema construction produces errors.

### DIFF
--- a/python/examples/math/program.py
+++ b/python/examples/math/program.py
@@ -45,8 +45,7 @@ FunctionCall = TypedDict(
 
 translation_result = python_type_to_typescript_schema(JsonProgram)
 program_schema_text = translation_result.typescript_schema_str
-print(program_schema_text)
-print(translation_result.errors)
+
 
 JsonValue = str | int | float | bool | None | dict[str, "JsonValue"] | list["JsonValue"]
 
@@ -127,7 +126,7 @@ class TypeChatProgramTranslator(TypeChatTranslator[JsonProgram]):
     _api_declaration_str: str
 
     def __init__(self, model: TypeChatLanguageModel, validator: TypeChatProgramValidator, api_type: type):
-        super().__init__(model=model, validator=validator, target_type=api_type)
+        super().__init__(model=model, validator=validator, target_type=api_type, _raise_on_schema_errors = False)
         # TODO: the conversion result here has errors!
         conversion_result = python_type_to_typescript_schema(api_type)
         self._api_declaration_str = conversion_result.typescript_schema_str

--- a/python/examples/music/client.py
+++ b/python/examples/music/client.py
@@ -266,12 +266,13 @@ async def handle_call(action: PlayerAction, context: ClientContext):
         case "selectDevice":
             deviceKeyword = action["parameters"]["keyword"].lower()
             devices = await context.service.devices()
+            devices = devices["devices"]
             target_device = next(
-                (d for d in devices if d.name.lower() == deviceKeyword or d.type.lower() == deviceKeyword), None # type: ignore
+                (d for d in devices if d["name"].lower() == deviceKeyword or d["type"].lower() == deviceKeyword), None
             )
             if target_device:
-                await context.service.transfer_playback(device_id=target_device.id) # type: ignore
-                print(f"Selected device {target_device.name} of type {target_device.type}") # type: ignore
+                await context.service.transfer_playback(device_id=target_device)
+                print(f"Selected device {target_device}")
         case "setVolume":
             new_volume = action["parameters"].get("newVolumeLevel", None)
             new_volume = max(0, min(new_volume, 100))

--- a/python/examples/music/schema.py
+++ b/python/examples/music/schema.py
@@ -109,7 +109,7 @@ class ListDevicesAction(TypedDict):
     parameters: EmptyParameters
 
 
-class SelectDecviceActionParameters(TypedDict):
+class SelectDeviceActionParameters(TypedDict):
     keyword: Annotated[str, Doc("keyword to match against device name")]
 
 
@@ -119,7 +119,7 @@ class SelectDeviceAction(TypedDict):
     """
 
     actionName: Literal["selectDevice"]
-    parameters: SelectDecviceActionParameters
+    parameters: SelectDeviceActionParameters
 
 
 class SelectVolumeActionParameters(TypedDict):

--- a/python/examples/music/spotipyWrapper.py
+++ b/python/examples/music/spotipyWrapper.py
@@ -1,5 +1,5 @@
 from typing_extensions import Any
-from pydantic.dataclasses import dataclass, field
+from dataclasses import dataclass, field
 import spotipy # type: ignore
 
 # The spotipy library does not provide type hints or async methods. This file has some wrappers and stubs 

--- a/python/src/typechat/_internal/translator.py
+++ b/python/src/typechat/_internal/translator.py
@@ -19,7 +19,14 @@ class TypeChatTranslator(Generic[T]):
     _schema_str: str
     _max_repair_attempts = 1
 
-    def __init__(self, model: TypeChatLanguageModel, validator: TypeChatValidator[T], target_type: type[T]):
+    def __init__(
+        self,
+        model: TypeChatLanguageModel,
+        validator: TypeChatValidator[T],
+        target_type: type[T],
+        *, # keyword-only parameters follow
+        _raise_on_schema_errors: bool = True,
+    ):
         """
         Args:
             model: The associated `TypeChatLanguageModel`.
@@ -32,9 +39,10 @@ class TypeChatTranslator(Generic[T]):
         self.target_type = target_type
 
         conversion_result = python_type_to_typescript_schema(target_type)
-        # TODO: Examples may not work here!
-        # if conversion_result.errors:
-        #     raise ValueError(f"Could not convert Python type to TypeScript schema: {conversion_result.errors}")
+
+        if _raise_on_schema_errors and conversion_result.errors:
+            error_text = "".join(f"\n- {error}" for error in conversion_result.errors)
+            raise ValueError(f"Could not convert Python type to TypeScript schema: \n{error_text}")
         self._type_name = conversion_result.typescript_type_reference
         self._schema_str = conversion_result.typescript_schema_str
 


### PR DESCRIPTION
The current model for TypeChat in Python is to construct a TypeScript schema and use it regardless of if there are issues with the input. This is possible because the translation process was designed to produce an approximation of some TypeScript schema while producing a set of errors.

Surprisingly, our `math` demo takes advantage of this, providing a Python type which can't be translated into a TS schema. But this still works well enough for the demo!

So by default, failure to construct a schema will now *always* raise an error; however, `TypeChatProgramTranslator` now takes an experimental named `_raise_on_schema_errors` parameter which can be specified as `False` to opt out of this behavior.
