### PR TITLE
Fix `typescript/healthData` and search upward for `.env` files in TS examples.

### DIFF
--- a/typescript/examples/calendar/package.json
+++ b/typescript/examples/calendar/package.json
@@ -12,9 +12,11 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/calendar/src/main.ts
+++ b/typescript/examples/calendar/src/main.ts
@@ -1,12 +1,15 @@
+import assert from "assert";
+import dotenv from "dotenv";
+import findConfig from "find-config";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
-import { createLanguageModel, createJsonTranslator, processRequests } from "typechat";
+import { createJsonTranslator, createLanguageModel, processRequests } from "typechat";
 import { createTypeScriptJsonValidator } from "typechat/ts";
 import { CalendarActions } from './calendarActionsSchema';
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "calendarActionsSchema.ts"), "utf8");

--- a/typescript/examples/coffeeShop-zod/package.json
+++ b/typescript/examples/coffeeShop-zod/package.json
@@ -12,10 +12,12 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/coffeeShop-zod/src/main.ts
+++ b/typescript/examples/coffeeShop-zod/src/main.ts
@@ -1,12 +1,14 @@
-import path from "path";
+import assert from "assert";
 import dotenv from "dotenv";
-import { z } from "zod";
-import { createLanguageModel, createJsonTranslator, processRequests } from "typechat";
+import findConfig from "find-config";
+import { createJsonTranslator, createLanguageModel, processRequests } from "typechat";
 import { createZodJsonValidator } from "typechat/zod";
+import { z } from "zod";
 import { CoffeeShopSchema } from "./coffeeShopSchema";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const validator = createZodJsonValidator(CoffeeShopSchema, "Cart");

--- a/typescript/examples/coffeeShop/package.json
+++ b/typescript/examples/coffeeShop/package.json
@@ -12,9 +12,11 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/coffeeShop/src/main.ts
+++ b/typescript/examples/coffeeShop/src/main.ts
@@ -1,12 +1,15 @@
+import assert from "assert";
+import dotenv from "dotenv";
+import findConfig from "find-config";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
-import { createLanguageModel, createJsonTranslator, processRequests } from "typechat";
+import { createJsonTranslator, createLanguageModel, processRequests } from "typechat";
 import { createTypeScriptJsonValidator } from "typechat/ts";
 import { Cart } from "./coffeeShopSchema";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "coffeeShopSchema.ts"), "utf8");

--- a/typescript/examples/healthData/package.json
+++ b/typescript/examples/healthData/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
-    "typechat": "^0.0.10"
+    "typechat": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.3.1",

--- a/typescript/examples/healthData/package.json
+++ b/typescript/examples/healthData/package.json
@@ -12,9 +12,11 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.3.1",
     "copyfiles": "^2.4.1",
     "typescript": "^5.1.3"

--- a/typescript/examples/healthData/src/main.ts
+++ b/typescript/examples/healthData/src/main.ts
@@ -1,12 +1,15 @@
+import assert from "assert";
+import dotenv from "dotenv";
+import findConfig from "find-config";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
-import { createHealthDataTranslator } from "./translator";
 import { createLanguageModel, processRequests } from "typechat";
 import { HealthDataResponse } from "./healthDataSchema";
+import { createHealthDataTranslator } from "./translator";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const healthInstructions = `
 Help me enter my health data step by step.

--- a/typescript/examples/healthData/src/translator.ts
+++ b/typescript/examples/healthData/src/translator.ts
@@ -1,4 +1,5 @@
 import {Result, TypeChatLanguageModel, createJsonTranslator, TypeChatJsonTranslator} from "typechat";
+import { createTypeScriptJsonValidator } from "../../../dist/ts";
 
 type ChatMessage = {
     source: "system" | "user" | "assistant";
@@ -18,7 +19,8 @@ export function createHealthDataTranslator<T extends object>(model: TypeChatLang
     const _maxPromptLength = 2048;
     const _additionalAgentInstructions = additionalAgentInstructions;
     
-    const _translator = createJsonTranslator<T>(model, schema, typename);
+    const validator = createTypeScriptJsonValidator<T>(schema, typename);
+    const _translator = createJsonTranslator(model, validator);
     _translator.createRequestPrompt = createRequestPrompt;
     
     const customtranslator: TranslatorWithHistory<T> = {

--- a/typescript/examples/math/package.json
+++ b/typescript/examples/math/package.json
@@ -12,9 +12,11 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/math/src/main.ts
+++ b/typescript/examples/math/src/main.ts
@@ -1,11 +1,14 @@
+import assert from "assert";
+import dotenv from "dotenv";
+import findConfig from "find-config";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
-import { createLanguageModel, processRequests, getData } from "typechat";
-import { createProgramTranslator, createModuleTextFromProgram, evaluateJsonProgram } from "typechat/ts";
+import { createLanguageModel, getData, processRequests } from "typechat";
+import { createModuleTextFromProgram, createProgramTranslator, evaluateJsonProgram } from "typechat/ts";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "mathSchema.ts"), "utf8");

--- a/typescript/examples/multiSchema/package.json
+++ b/typescript/examples/multiSchema/package.json
@@ -14,9 +14,11 @@
   "dependencies": {
     "dotenv": "^16.3.1",
     "typechat": "^0.1.0",
+    "find-config": "^1.0.0",
     "music": "^0.0.1"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.3.1",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/multiSchema/src/main.ts
+++ b/typescript/examples/multiSchema/src/main.ts
@@ -1,12 +1,15 @@
+import assert from "assert";
+import dotenv from "dotenv";
+import findConfig from "find-config";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
+import { createLanguageModel, processRequests } from "typechat";
 import { createJsonMathAgent, createJsonPrintAgent } from "./agent";
-import {createLanguageModel, processRequests } from "typechat";
 import { createAgentRouter } from "./router";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const taskClassificationSchema = fs.readFileSync(path.join(__dirname, "classificationSchema.ts"), "utf8");

--- a/typescript/examples/music/package.json
+++ b/typescript/examples/music/package.json
@@ -18,12 +18,14 @@
     "chalk": "^2.3.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "find-config": "^1.0.0",
     "open": "^7.0.4",
     "sqlite3": "^5.1.6",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "@types/spotify-api": "^0.0.22",
     "copyfiles": "^2.4.1",

--- a/typescript/examples/restaurant/package.json
+++ b/typescript/examples/restaurant/package.json
@@ -12,9 +12,11 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/restaurant/src/main.ts
+++ b/typescript/examples/restaurant/src/main.ts
@@ -1,9 +1,11 @@
+import assert from "assert";
+import dotenv from "dotenv";
+import findConfig from "find-config";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
 import {
-  createLanguageModel,
   createJsonTranslator,
+  createLanguageModel,
   processRequests,
 } from "typechat";
 import {
@@ -11,8 +13,9 @@ import {
 } from "typechat/ts";
 import { Order } from "./foodOrderViewSchema";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const viewSchema = fs.readFileSync(

--- a/typescript/examples/sentiment-zod/package.json
+++ b/typescript/examples/sentiment-zod/package.json
@@ -12,9 +12,11 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/sentiment-zod/src/main.ts
+++ b/typescript/examples/sentiment-zod/src/main.ts
@@ -1,11 +1,13 @@
-import path from "path";
+import assert from "assert";
 import dotenv from "dotenv";
-import { createLanguageModel, createJsonTranslator, processRequests } from "typechat";
+import findConfig from "find-config";
+import { createJsonTranslator, createLanguageModel, processRequests } from "typechat";
 import { createZodJsonValidator } from "typechat/zod";
 import { SentimentSchema } from "./sentimentSchema";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const validator = createZodJsonValidator(SentimentSchema, "SentimentResponse");

--- a/typescript/examples/sentiment/package.json
+++ b/typescript/examples/sentiment/package.json
@@ -12,9 +12,11 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "find-config": "^1.0.0",
     "typechat": "^0.1.0"
   },
   "devDependencies": {
+    "@types/find-config": "1.0.4",
     "@types/node": "^20.10.4",
     "copyfiles": "^2.4.1",
     "typescript": "^5.3.3"

--- a/typescript/examples/sentiment/src/main.ts
+++ b/typescript/examples/sentiment/src/main.ts
@@ -1,12 +1,15 @@
+import assert from "assert";
+import dotenv from "dotenv";
+import findConfig from "find-config";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
-import { createLanguageModel, createJsonTranslator, processRequests } from "typechat";
+import { createJsonTranslator, createLanguageModel, processRequests } from "typechat";
 import { createTypeScriptJsonValidator } from "typechat/ts";
 import { SentimentResponse } from "./sentimentSchema";
 
-// TODO: use local .env file.
-dotenv.config({ path: path.join(__dirname, "../../../.env") });
+const dotEnvPath = findConfig(".env");
+assert(dotEnvPath, ".env file not found!");
+dotenv.config({ path: dotEnvPath });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "sentimentSchema.ts"), "utf8");

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -28,9 +28,11 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -42,9 +44,11 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -56,10 +60,12 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "typechat": "^0.1.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -71,27 +77,14 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
-        "typechat": "^0.0.10"
+        "find-config": "^1.0.0",
+        "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.3.1",
         "copyfiles": "^2.4.1",
         "typescript": "^5.1.3"
-      }
-    },
-    "examples/healthData/node_modules/typechat": {
-      "version": "0.0.10",
-      "license": "MIT",
-      "workspaces": [
-        "./",
-        "./examples/*"
-      ],
-      "dependencies": {
-        "axios": "^1.4.0",
-        "typescript": "^5.1.3"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "examples/math": {
@@ -99,9 +92,11 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -113,10 +108,12 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "music": "^0.0.1",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.3.1",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -130,12 +127,14 @@
         "chalk": "^2.3.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "find-config": "^1.0.0",
         "open": "^7.0.4",
         "sqlite3": "^5.1.6",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "@types/spotify-api": "^0.0.22",
         "copyfiles": "^2.4.1",
@@ -147,9 +146,11 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -160,9 +161,11 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -173,9 +176,11 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",
+        "find-config": "^1.0.0",
         "typechat": "^0.1.0"
       },
       "devDependencies": {
+        "@types/find-config": "1.0.4",
         "@types/node": "^20.10.4",
         "copyfiles": "^2.4.1",
         "typescript": "^5.3.3"
@@ -252,9 +257,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.43",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
+      "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -262,6 +267,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/find-config": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/find-config/-/find-config-1.0.4.tgz",
+      "integrity": "sha512-BCXaKgzHK7KnfCQBRQBWGTA+QajOE9uFolXPt+9EktiiMS56D8oXF2ZCh9eCxuEyfqDmX/mYIcmWg9j9f659eg==",
+      "dev": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -276,18 +287,18 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
-      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.11",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
+      "version": "6.9.12",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
+      "integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -474,9 +485,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
@@ -548,12 +559,12 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -561,7 +572,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -645,13 +656,18 @@
       "link": true
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -839,16 +855,19 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -891,14 +910,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.2.tgz",
-      "integrity": "sha512-HTlk5nmhkm8F6JcdXvHIzaorzCoziNQT9mGxLPVXW8wJF1TiGSL60ZGB4gHWabHOaMmWmhvk2/lPHfnBiT78AQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {
@@ -964,10 +983,29 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "optional": true
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1003,13 +1041,13 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
+      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -1063,6 +1101,17 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-config/-/find-config-1.0.0.tgz",
+      "integrity": "sha512-Z+suHH+7LSE40WfUeZPIxSxypCWvrzdVc60xAjUShZeT5eMWM0/FQUduq3HjluyfAHWvC/aOBkT1pTZktyF/jg==",
+      "dependencies": {
+        "user-home": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/follow-redirects": {
@@ -1172,14 +1221,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1236,20 +1289,20 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1275,9 +1328,9 @@
       "optional": true
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1466,11 +1519,18 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "optional": true
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "optional": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1530,6 +1590,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "optional": true
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "optional": true
     },
     "node_modules/lru-cache": {
@@ -1787,9 +1853,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
-      "integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+      "integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1911,6 +1977,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -1949,9 +2023,9 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -2047,9 +2121,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -2148,9 +2222,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2218,13 +2292,14 @@
       "optional": true
     },
     "node_modules/set-function-length": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
-      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
       "dependencies": {
-        "define-data-property": "^1.1.1",
+        "define-data-property": "^1.1.2",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.2",
+        "get-intrinsic": "^1.2.3",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.1"
       },
@@ -2238,13 +2313,17 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2310,16 +2389,16 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
+      "integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
       "optional": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -2358,6 +2437,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "optional": true
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "optional": true
     },
     "node_modules/sqlite3": {
@@ -2662,6 +2747,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/util-deprecate": {


### PR DESCRIPTION
This PR does two things.

First, it fixes the `typescript/healthData` example by bumping the version and fixing up the example. In principle, I expect the changes should be the same as #197, but without any formatting changes other than import ordering

Second, it changes all our examples to use combine `dotenv` with `find-config` [as suggested here](https://github.com/motdotla/dotenv/issues/238#issuecomment-348017037) so that `.env` files can be placed at the top level of the repo.