### PR TITLE
Specify `override` for every TS dotenv call.

### DIFF
--- a/typescript/examples/calendar/src/main.ts
+++ b/typescript/examples/calendar/src/main.ts
@@ -9,7 +9,7 @@ import { CalendarActions } from './calendarActionsSchema';
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "calendarActionsSchema.ts"), "utf8");

--- a/typescript/examples/coffeeShop-zod/src/main.ts
+++ b/typescript/examples/coffeeShop-zod/src/main.ts
@@ -8,7 +8,7 @@ import { CoffeeShopSchema } from "./coffeeShopSchema";
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const validator = createZodJsonValidator(CoffeeShopSchema, "Cart");

--- a/typescript/examples/coffeeShop/src/main.ts
+++ b/typescript/examples/coffeeShop/src/main.ts
@@ -9,7 +9,7 @@ import { Cart } from "./coffeeShopSchema";
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "coffeeShopSchema.ts"), "utf8");

--- a/typescript/examples/healthData/src/main.ts
+++ b/typescript/examples/healthData/src/main.ts
@@ -9,7 +9,7 @@ import { createHealthDataTranslator } from "./translator";
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const healthInstructions = `
 Help me enter my health data step by step.

--- a/typescript/examples/math/src/main.ts
+++ b/typescript/examples/math/src/main.ts
@@ -8,7 +8,7 @@ import { createModuleTextFromProgram, createProgramTranslator, evaluateJsonProgr
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "mathSchema.ts"), "utf8");

--- a/typescript/examples/multiSchema/src/main.ts
+++ b/typescript/examples/multiSchema/src/main.ts
@@ -9,7 +9,7 @@ import { createAgentRouter } from "./router";
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const taskClassificationSchema = fs.readFileSync(path.join(__dirname, "classificationSchema.ts"), "utf8");

--- a/typescript/examples/restaurant/src/main.ts
+++ b/typescript/examples/restaurant/src/main.ts
@@ -15,7 +15,7 @@ import { Order } from "./foodOrderViewSchema";
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const viewSchema = fs.readFileSync(

--- a/typescript/examples/sentiment-zod/src/main.ts
+++ b/typescript/examples/sentiment-zod/src/main.ts
@@ -7,7 +7,7 @@ import { SentimentSchema } from "./sentimentSchema";
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const validator = createZodJsonValidator(SentimentSchema, "SentimentResponse");

--- a/typescript/examples/sentiment/src/main.ts
+++ b/typescript/examples/sentiment/src/main.ts
@@ -9,7 +9,7 @@ import { SentimentResponse } from "./sentimentSchema";
 
 const dotEnvPath = findConfig(".env");
 assert(dotEnvPath, ".env file not found!");
-dotenv.config({ path: dotEnvPath });
+dotenv.config({ path: dotEnvPath, override: true });
 
 const model = createLanguageModel(process.env);
 const schema = fs.readFileSync(path.join(__dirname, "sentimentSchema.ts"), "utf8");


### PR DESCRIPTION
Fixes issues if (for some reason) environment variables are already specified.