### PR TITLE
Fix validation against dataclasses

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "pydantic>=2.5.2",
+  "pydantic_core>=2.16.3",
   "httpx>=0.27.0",
   "typing_extensions>=4.10.0",
 ]
@@ -64,7 +65,7 @@ cov = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.11"]
+python = ["3.11", "3.12"]
 
 [tool.hatch.envs.lint]
 detached = true

--- a/python/src/typechat/_internal/validator.py
+++ b/python/src/typechat/_internal/validator.py
@@ -1,5 +1,5 @@
 import json
-from typing_extensions import overload, Generic, TypeVar
+from typing_extensions import Generic, TypeVar
 
 import pydantic
 import pydantic_core

--- a/python/src/typechat/_internal/validator.py
+++ b/python/src/typechat/_internal/validator.py
@@ -1,7 +1,8 @@
 import json
-from typing_extensions import Generic, TypeVar
+from typing_extensions import overload, Generic, TypeVar
 
 import pydantic
+import pydantic_core
 
 from typechat._internal.result import Failure, Result, Success
 
@@ -26,14 +27,19 @@ class TypeChatValidator(Generic[T]):
     def validate_object(self, obj: object) -> Result[T]:
         """
         Validates the given Python object according to the associated schema type.
-        
-        Useful for translators that may presume a non-JSON output.
 
         Returns a `Success[T]` object containing the object if validation was successful.
         Otherwise, returns a `Failure` object with a `message` property describing the error.
         """
         try:
-            typed_dict = self._adapted_type.validate_python(obj, strict=True)
+            # TODO: Switch to `validate_python` when validation modes are exposed.
+            # https://github.com/pydantic/pydantic-core/issues/712
+            # We'd prefer to keep `validate_object` as the core method and
+            # allow translators to concern themselves with the JSON instead.
+            # However, under Pydantic's `strict` mode, a `dict` isn't considered compatible
+            # with a dataclass. So for now, jump back to JSON and validate the string.
+            json_str = pydantic_core.to_json(obj)
+            typed_dict = self._adapted_type.validate_json(json_str, strict=True)
             return Success(typed_dict)
         except pydantic.ValidationError as validation_error:
             return _handle_error(validation_error)

--- a/python/tests/test_validator.py
+++ b/python/tests/test_validator.py
@@ -1,0 +1,15 @@
+
+from dataclasses import dataclass
+import typechat
+
+@dataclass
+class Example:
+    a: str
+    b: int
+    c: bool
+
+v = typechat.TypeChatValidator(Example)
+
+def test_dict_valid_as_dataclass():
+    r = v.validate_object({"a": "hello!", "b": 42, "c": True})
+    assert r == typechat.Success(Example(a="hello!", b=42, c=True))

--- a/python/tests/test_validator.py
+++ b/python/tests/test_validator.py
@@ -13,3 +13,4 @@ v = typechat.TypeChatValidator(Example)
 def test_dict_valid_as_dataclass():
     r = v.validate_object({"a": "hello!", "b": 42, "c": True})
     assert r == typechat.Success(Example(a="hello!", b=42, c=True))
+    


### PR DESCRIPTION
In #201 and #208, I switched us over from using Pydantic's `validate_json` to `validate_python`. However, there's a subtlety. [From the docs](https://docs.pydantic.dev/latest/api/pydantic_core/#pydantic_core.SchemaValidator.validate_json):

> It also handles constructing the correct Python type even in strict mode, where `validate_python(json.loads(json_data))` would fail validation.

That might sound surprising if you don't catch what happens at each step. The subtlety here is that by the time data is loaded up from `json.loads`, it comes in as a `dict`. Under `strict=True`, that `dict` is not compatible with any type other than certain kinds of `dict`s and `TypedDict`s. So 

Pydantic already has issues at https://github.com/pydantic/pydantic-core/issues/712 and https://github.com/pydantic/pydantic/issues/9009 to enable the same flexibilities that `validate_json` has, but for now [the recommended workaround is to reserialize and use `validate_json`](https://github.com/pydantic/pydantic-core/pull/717#issuecomment-1614217388).