### PR TITLE
Make it easier to use purely `pip` and `venv` instead of requiring Hatch

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -24,37 +24,18 @@ Install TypeChat:
 pip install typechat
 ```
 
-You can also develop TypeChat from source, which needs [Python >=3.11](https://www.python.org/downloads/).
-
-It can be managed through [hatch](https://hatch.pypa.io/1.6/install/):
+You can also develop TypeChat from source, which needs [Python >=3.11](https://www.python.org/downloads/), [hatch](https://hatch.pypa.io/1.6/install/), and [Node.js >=20](https://nodejs.org/en/download):
 
 ```sh
 git clone https://github.com/microsoft/TypeChat
 cd TypeChat/python
 hatch shell
-```
-
-Or with a custom virtual environment:
-
-```sh
-git clone https://github.com/microsoft/TypeChat
-cd TypeChat/python
-python -m venv ../.venv
-
-# Activate the virtual environment
-# Windows
-../.venv/Scripts/Activate.ps1
-# Unix/POSIX
-source ../.venv/bin/activate
-
-# Dependencies for running tests, type-checking, etc.
-pip install .[dev-dependencies]
 npm ci
-
-# Dependencies for running examples.
-pip install .[example-dependencies]
-
 ```
+
+To see TypeChat in action, we recommend exploring the [TypeChat example projects](https://github.com/microsoft/TypeChat/tree/main/python/examples). You can try them on your local machine or in a GitHub Codespace.
+
+To learn more about TypeChat, visit the [documentation](https://microsoft.github.io/TypeChat) which includes more information on TypeChat and how to get started.
 
 ## Contributing
 

--- a/python/README.md
+++ b/python/README.md
@@ -16,16 +16,44 @@ After defining your types, TypeChat takes care of the rest by:
 
 Types are all you need!
 
-## Installation
+## Getting Started
 
-TypeChat for Python is not yet on PyPI, but you can try our [examples](./examples/) by cloning this repository.
+Install TypeChat:
 
-You will need [Python >=3.11](https://www.python.org/downloads/) and [hatch](https://hatch.pypa.io/1.6/install/).
+```sh
+pip install typechat
+```
+
+You can also develop TypeChat from source, which needs [Python >=3.11](https://www.python.org/downloads/).
+
+It can be managed through [hatch](https://hatch.pypa.io/1.6/install/):
 
 ```sh
 git clone https://github.com/microsoft/TypeChat
 cd TypeChat/python
 hatch shell
+```
+
+Or with a custom virtual environment:
+
+```sh
+git clone https://github.com/microsoft/TypeChat
+cd TypeChat/python
+python -m venv ../.venv
+
+# Activate the virtual environment
+# Windows
+../.venv/Scripts/Activate.ps1
+# Unix/POSIX
+source ../.venv/bin/activate
+
+# Dependencies for running tests, type-checking, etc.
+pip install .[dev-dependencies]
+npm ci
+
+# Dependencies for running examples.
+pip install .[example-dependencies]
+
 ```
 
 ## Contributing

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -34,6 +34,23 @@ hatch shell
 python examples/sentiment/demo.py
 ```
 
+Alternatively, you can just use `venv` and `pip`:
+
+```sh
+git clone https://github.com/microsoft/TypeChat
+cd TypeChat/python
+python -m venv ../.venv
+
+# Activate the virtual environment
+# Windows
+../.venv/Scripts/Activate.ps1
+# Unix/POSIX
+source ../.venv/bin/activate
+
+pip install .[example-dependencies]
+
+python examples/sentiment/demo.py
+```
 
 ### Option 2: GitHub Codespaces
 

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -47,7 +47,7 @@ python -m venv ../.venv
 # Unix/POSIX
 source ../.venv/bin/activate
 
-pip install .[example-dependencies]
+pip install .[examples]
 
 python examples/sentiment/demo.py
 ```

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,6 +28,18 @@ dependencies = [
   "typing_extensions>=4.10.0",
 ]
 
+[project.optional-dependencies]
+dev-dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest>=8.0.2",
+  "syrupy>=4.6.1",
+]
+
+example-dependencies = [
+  "python-dotenv>=1.0.0",
+  "spotipy",
+]
+
 [project.urls]
 Documentation = "https://github.com/microsoft/TypeChat#readme"
 Issues = "https://github.com/microsoft/TypeChat/issues"
@@ -44,12 +56,9 @@ path = "src/typechat/__about__.py"
 type = "virtual"
 path = "../.venv"
 
-dependencies = [
-  "coverage[toml]>=6.5",
-  "python-dotenv>=1.0.0",
-  "pytest>=8.0.2",
-  "syrupy>=4.6.1",
-  "spotipy", # for examples
+features = [
+  "dev-dependencies",
+  "example-dependencies"
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,13 +29,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev-dependencies = [
+# Development-time dependencies.
+dev = [
   "coverage[toml]>=6.5",
   "pytest>=8.0.2",
   "syrupy>=4.6.1",
 ]
 
-example-dependencies = [
+# Dependencies for examples.
+examples = [
   "python-dotenv>=1.0.0",
   "spotipy",
 ]
@@ -56,9 +58,11 @@ path = "src/typechat/__about__.py"
 type = "virtual"
 path = "../.venv"
 
+# Include dependencies from optional-dependencies for
+# development of the core package along with examples.
 features = [
-  "dev-dependencies",
-  "example-dependencies"
+  "dev",
+  "examples"
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -33,7 +33,7 @@ npm install
 npm run build
 ```
 
-To see TypeChat in action, we recommend exploring the [TypeChat example projects](./examples). You can try them on your local machine or in a GitHub Codespace.
+To see TypeChat in action, we recommend exploring the [TypeChat example projects](https://github.com/microsoft/TypeChat/tree/main/typescript/examples). You can try them on your local machine or in a GitHub Codespace.
 
 To learn more about TypeChat, visit the [documentation](https://microsoft.github.io/TypeChat) which includes more information on TypeChat and how to get started.
 


### PR DESCRIPTION
In #207, I made it so that hatch would create a `.venv` in the repository root. The reason was to make common scenarios work better for editors (most which currently don't understand hatch).

Still, lots of people don't use Hatch, and in #215, @pamelafox pointed out that it's nice to have control over this stuff. So this PR makes it possible to use use pip directly with our `pyproject.toml`. To do so, dev-time dependencies for TypeChat, along with dependencies for our examples, are moved into their own respective arrays in `optional-dependencies`.

Since pip allows you to install "extras" (see [here](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#install-extras), [here](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras), and [here](https://pip.pypa.io/en/stable/cli/pip_install/#:~:text=Install%20a%20package%20with%20extras)), developers can just write something like the following:

```sh
cd TypeChat/python
python -v venv ../.venv
source ../.venv/bin/activate
pip install .[dev,examples]
```