### PR TITLE
Use readline for interactive input

### DIFF
--- a/python/src/typechat/_internal/interactive.py
+++ b/python/src/typechat/_internal/interactive.py
@@ -28,8 +28,7 @@ async def process_requests(interactive_prompt: str, input_file_name: str | None,
             except EOFError:
                 print("\n")
                 break
-            lower_line = line.lower().strip()
-            if lower_line == "quit" or lower_line == "exit":
+            if line.lower().strip() in ("quit", "exit"):
                 break
             else:
                 await process_request(line)

--- a/python/src/typechat/_internal/interactive.py
+++ b/python/src/typechat/_internal/interactive.py
@@ -21,13 +21,15 @@ async def process_requests(interactive_prompt: str, input_file_name: str | None,
                 print(interactive_prompt + line)
                 await process_request(line)
     else:
-        print(interactive_prompt, end="", flush=True)
-        for line in sys.stdin:
+        import readline  # Enable input editing and history
+        while True:
+            try:
+                line = input(interactive_prompt)
+            except EOFError:
+                print("\n")
+                break
             lower_line = line.lower().strip()
             if lower_line == "quit" or lower_line == "exit":
                 break
             else:
                 await process_request(line)
-                print(interactive_prompt, end="", flush=True)
-
-                

--- a/python/src/typechat/_internal/interactive.py
+++ b/python/src/typechat/_internal/interactive.py
@@ -21,7 +21,8 @@ async def process_requests(interactive_prompt: str, input_file_name: str | None,
                 print(interactive_prompt + line)
                 await process_request(line)
     else:
-        import readline  # Enable input editing and history
+        # Use readline to enable input editing and history
+        import readline  # type: ignore
         while True:
             try:
                 line = input(interactive_prompt)

--- a/python/src/typechat/_internal/interactive.py
+++ b/python/src/typechat/_internal/interactive.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Callable, Awaitable
 
 async def process_requests(interactive_prompt: str, input_file_name: str | None, process_request: Callable[[str], Awaitable[None]]):


### PR DESCRIPTION
Importing the readline module and using input() instead of sys.stdin turns on command line editing, including history.
For a REPL dinosaur like myself this is essential. :-)