### PR TITLE
Various doc updates and expose some internals

### DIFF
--- a/python/examples/sentiment/demo.py
+++ b/python/examples/sentiment/demo.py
@@ -17,7 +17,7 @@ async def main():
             print(result.message)
         else:
             result = result.value
-            print(f"The sentiment is {result['sentiment']}")
+            print(f"The sentiment is {result.sentiment}")
 
     file_path = sys.argv[1] if len(sys.argv) == 2 else None
     await process_requests("😀> ", file_path, request_handler)

--- a/python/examples/sentiment/schema.py
+++ b/python/examples/sentiment/schema.py
@@ -1,7 +1,8 @@
-from typing_extensions import Literal, TypedDict, Annotated, Doc
+from dataclasses import dataclass
+from typing_extensions import Literal, Annotated, Doc
 
-
-class Sentiment(TypedDict):
+@dataclass
+class Sentiment:
     """
     The following is a schema definition for determining the sentiment of a some user input.
     """

--- a/python/src/typechat/_internal/validator.py
+++ b/python/src/typechat/_internal/validator.py
@@ -10,7 +10,7 @@ T = TypeVar("T", covariant=True)
 
 class TypeChatValidator(Generic[T]):
     """
-    Validates JSON text against a given Python type.
+    Validates an object against a given Python type.
     """
 
     _adapted_type: pydantic.TypeAdapter[T]


### PR DESCRIPTION
While the actual `HttpxLanguageModel` is still in an `_internal` module, I want people to be able to experiment and be able to set the relevant attributes.

Also switches our sentiment example to be a dataclass.