### PR TITLE
Actually test the Python translator

### DIFF
--- a/python/examples/healthData/translator.py
+++ b/python/examples/healthData/translator.py
@@ -27,8 +27,8 @@ class TranslatorWithHistory(TypeChatJsonTranslator[T]):
         self._additional_agent_instructions = additional_agent_instructions
 
     @override
-    async def translate(self, request: str, *, prompt_preamble: str | list[PromptSection] | None = None) -> Result[T]:
-        result = await super().translate(request=request, prompt_preamble=prompt_preamble)
+    async def translate(self, input: str, *, prompt_preamble: str | list[PromptSection] | None = None) -> Result[T]:
+        result = await super().translate(input=input, prompt_preamble=prompt_preamble)
         if not isinstance(result, Failure):
             self._chat_history.append(ChatMessage(source="assistant", body=result.value))
         return result

--- a/python/tests/__snapshots__/test_translator.ambr
+++ b/python/tests/__snapshots__/test_translator.ambr
@@ -1,0 +1,84 @@
+# serializer version: 1
+# name: test_translator_with_immediate_pass
+  list([
+    dict({
+      'kind': 'CLIENT REQUEST',
+      'payload': '''
+        
+        You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
+        ```
+        interface ExampleABC {
+            a: string;
+            b: boolean;
+            c: number;
+        }
+        
+        ```
+        The following is a user request:
+        '''
+        Get me stuff.
+        '''
+        The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
+  
+      ''',
+    }),
+    dict({
+      'kind': 'MODEL RESPONSE',
+      'payload': '{ "a": "hello", "b": true, "c": 1234 }',
+    }),
+  ])
+# ---
+# name: test_translator_with_single_failure
+  list([
+    dict({
+      'kind': 'CLIENT REQUEST',
+      'payload': '''
+        
+        You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
+        ```
+        interface ExampleABC {
+            a: string;
+            b: boolean;
+            c: number;
+        }
+        
+        ```
+        The following is a user request:
+        '''
+        Get me stuff.
+        '''
+        The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
+  
+      ''',
+    }),
+    dict({
+      'kind': 'MODEL RESPONSE',
+      'payload': '{ "a": "hello", "b": true }',
+    }),
+    dict({
+      'kind': 'CLIENT REQUEST',
+      'payload': '''
+        
+        You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
+        ```
+        interface ExampleABC {
+            a: string;
+            b: boolean;
+            c: number;
+        }
+        
+        ```
+        The following is a user request:
+        '''
+        Get me stuff.
+        '''
+        The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
+  
+      ''',
+    }),
+    dict({
+      'kind': 'MODEL RESPONSE',
+      'payload': '{ "a": "hello", "b": true, "c": 1234 }',
+    }),
+  ])
+# ---

--- a/python/tests/__snapshots__/test_translator.ambr
+++ b/python/tests/__snapshots__/test_translator.ambr
@@ -3,24 +3,33 @@
   list([
     dict({
       'kind': 'CLIENT REQUEST',
-      'payload': '''
-        
-        You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
-        ```
-        interface ExampleABC {
-            a: string;
-            b: boolean;
-            c: number;
-        }
-        
-        ```
-        The following is a user request:
-        '''
-        Get me stuff.
-        '''
-        The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
+      'payload': list([
+        dict({
+          'content': 'Get me stuff.',
+          'role': 'user',
+        }),
+        dict({
+          'content': '''
+            
+            You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
+            ```
+            interface ExampleABC {
+                a: string;
+                b: boolean;
+                c: number;
+            }
+            
+            ```
+            The following is a user request:
+            '''
+            Get me stuff.
+            '''
+            The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
   
-      ''',
+          ''',
+          'role': 'user',
+        }),
+      ]),
     }),
     dict({
       'kind': 'MODEL RESPONSE',
@@ -32,24 +41,46 @@
   list([
     dict({
       'kind': 'CLIENT REQUEST',
-      'payload': '''
-        
-        You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
-        ```
-        interface ExampleABC {
-            a: string;
-            b: boolean;
-            c: number;
-        }
-        
-        ```
-        The following is a user request:
-        '''
-        Get me stuff.
-        '''
-        The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
+      'payload': list([
+        dict({
+          'content': 'Get me stuff.',
+          'role': 'user',
+        }),
+        dict({
+          'content': '''
+            
+            You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
+            ```
+            interface ExampleABC {
+                a: string;
+                b: boolean;
+                c: number;
+            }
+            
+            ```
+            The following is a user request:
+            '''
+            Get me stuff.
+            '''
+            The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
   
-      ''',
+          ''',
+          'role': 'user',
+        }),
+        dict({
+          'content': '''
+            
+            The above JSON object is invalid for the following reason:
+            '''
+            Validation path `c` failed for value `{"a": "hello", "b": true}` because:
+              Field required
+            '''
+            The following is a revised JSON object:
+  
+          ''',
+          'role': 'user',
+        }),
+      ]),
     }),
     dict({
       'kind': 'MODEL RESPONSE',
@@ -57,24 +88,46 @@
     }),
     dict({
       'kind': 'CLIENT REQUEST',
-      'payload': '''
-        
-        You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
-        ```
-        interface ExampleABC {
-            a: string;
-            b: boolean;
-            c: number;
-        }
-        
-        ```
-        The following is a user request:
-        '''
-        Get me stuff.
-        '''
-        The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
+      'payload': list([
+        dict({
+          'content': 'Get me stuff.',
+          'role': 'user',
+        }),
+        dict({
+          'content': '''
+            
+            You are a service that translates user requests into JSON objects of type "ExampleABC" according to the following TypeScript definitions:
+            ```
+            interface ExampleABC {
+                a: string;
+                b: boolean;
+                c: number;
+            }
+            
+            ```
+            The following is a user request:
+            '''
+            Get me stuff.
+            '''
+            The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
   
-      ''',
+          ''',
+          'role': 'user',
+        }),
+        dict({
+          'content': '''
+            
+            The above JSON object is invalid for the following reason:
+            '''
+            Validation path `c` failed for value `{"a": "hello", "b": true}` because:
+              Field required
+            '''
+            The following is a revised JSON object:
+  
+          ''',
+          'role': 'user',
+        }),
+      ]),
     }),
     dict({
       'kind': 'MODEL RESPONSE',

--- a/python/tests/test_translator.py
+++ b/python/tests/test_translator.py
@@ -1,0 +1,53 @@
+
+import asyncio
+from dataclasses import dataclass
+from typing_extensions import Any, Iterator, Literal, TypedDict, override
+import typechat
+
+class ConvoRecord(TypedDict):
+    kind: Literal["CLIENT REQUEST", "MODEL RESPONSE"]
+    payload: str | list[typechat.PromptSection]
+
+class FixedModel(typechat.TypeChatLanguageModel):
+    responses: Iterator[str]
+    conversation: list[ConvoRecord]
+
+    "A model which responds with one of a series of responses."
+    def __init__(self, responses: list[str]) -> None:
+        super().__init__()
+        self.responses = iter(responses)
+        self.conversation = []
+
+    @override
+    async def complete(self, prompt: str | list[typechat.PromptSection]) -> typechat.Result[str]:
+        self.conversation.append({ "kind": "CLIENT REQUEST", "payload": prompt })
+        response = next(self.responses)
+        self.conversation.append({ "kind": "MODEL RESPONSE", "payload": response })
+        return typechat.Success(response)
+
+@dataclass
+class ExampleABC:
+    a: str
+    b: bool
+    c: int
+
+v = typechat.TypeChatValidator(ExampleABC)
+
+def test_translator_with_immediate_pass(snapshot: Any):
+    m = FixedModel([
+        '{ "a": "hello", "b": true, "c": 1234 }',
+    ])
+    t = typechat.TypeChatJsonTranslator(m, v, ExampleABC)
+    asyncio.run(t.translate("Get me stuff."))
+    
+    assert m.conversation == snapshot
+
+def test_translator_with_single_failure(snapshot: Any):
+    m = FixedModel([
+        '{ "a": "hello", "b": true }',
+        '{ "a": "hello", "b": true, "c": 1234 }',
+    ])
+    t = typechat.TypeChatJsonTranslator(m, v, ExampleABC)
+    asyncio.run(t.translate("Get me stuff."))
+    
+    assert m.conversation == snapshot


### PR DESCRIPTION
This PR adds a test for Python translators by mocking a model and snapshotting the log.

Based on feedback from @gvanrossum where he pointed out that we don't actually use the repaired prompt (I broke this in #203). Some of the fixes are already in https://github.com/microsoft/TypeChat/pull/238.