### PR TITLE
Proposed alternate prompting scheme

### DIFF
--- a/python/src/typechat/_internal/translator.py
+++ b/python/src/typechat/_internal/translator.py
@@ -64,14 +64,14 @@ class TypeChatJsonTranslator(Generic[T]):
 
         messages: list[PromptSection] = []
 
-        messages.append({"role": "user", "content": input})
+        messages.append({"role": "system", "content": self._create_request_prompt(input)})
+
         if prompt_preamble:
             if isinstance(prompt_preamble, str):
                 prompt_preamble = [{"role": "user", "content": prompt_preamble}]
-            else:
-                messages.extend(prompt_preamble)
+            messages.extend(prompt_preamble)
 
-        messages.append({"role": "user", "content": self._create_request_prompt(input)})
+        messages.append({"role": "user", "content": input})
 
         num_repairs_attempted = 0
         while True:
@@ -103,11 +103,7 @@ You are a service that translates user requests into JSON objects of type "{self
 ```
 {self._schema_str}
 ```
-The following is a user request:
-'''
-{intent}
-'''
-The following is the user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:
+You translate each user request into a JSON object with 2 spaces of indentation and no properties with the value undefined.
 """
         return prompt
 


### PR DESCRIPTION
This is my proposal to address #39. It also fixes the issue I flagged in #240 about the user input being repeated twice. I tried it with my demo from #238 and that seems to work.

The prompt structure is as follows:

- System: "You are a ..., up to and including the schema, with instructions for how to format the JSON"
- prompt_prelude (user and bot messages)
- User: (the user request)

I don't understand how your test tools work (I'm a dinosaur, I don't know how hatch or toml or pipenv work, I can handle pytest though).

@DanielRosenwasser 