### PR TITLE
Enable passing images along with text for models that support multimodal input

### DIFF
--- a/typescript/src/model.ts
+++ b/typescript/src/model.ts
@@ -36,7 +36,16 @@ export type ImagePromptContent = {
 };
 
 export type ImageUrl = {
+    /*
+     * This could be a URL to a hosted image, or the base64-encoded image content.
+     */
     url: string;
+    
+    /*
+     * Controls how the model processes the image and generates its textual understanding.
+     * In "low res" mode, the model treats the image as 512x512px, while "high res" mode considers
+     * the image at full resolution.
+     */
     detail?: "auto" | "low" | "high";
 };
 

--- a/typescript/src/model.ts
+++ b/typescript/src/model.ts
@@ -43,8 +43,8 @@ export type ImageUrl = {
     
     /*
      * Controls how the model processes the image and generates its textual understanding.
-     * In "low res" mode, the model treats the image as 512x512px, while "high res" mode considers
-     * the image at full resolution.
+     * In "low" mode, the model treats the image as 512x512px, while "high" mode considers
+     * the image at full size.
      */
     detail?: "auto" | "low" | "high";
 };
@@ -168,10 +168,10 @@ function createFetchLanguageModel(url: string, headers: object, defaultParams: o
             const response = await fetch(url, options);
             if (response.ok) {
                 const json = await response.json() as { choices: { message: PromptSection }[] };
-                if (typeof json.choices[0].message.content  === 'string') {
+                if (typeof json.choices[0].message.content === "string") {
                     return success(json.choices[0].message.content ?? "");
                 } else {
-                    return error(`REST API unexpected response format :  ${JSON.stringify(json.choices[0].message.content)}`);
+                    return error(`REST API unexpected response format: ${JSON.stringify(json.choices[0].message.content)}`);
                 }
             }
             if (!isTransientHttpError(response.status) || retryCount >= retryMaxAttempts) {


### PR DESCRIPTION
 GPT-4-vision, GPT-4-omni and GPT-4-turbo allow multi-modal input, where images and text can be passed in the prompt. To support this, the content section of the prompt has an array of objects instead of just a string.
