### PR TITLE
Hatch Hotfix

### DIFF
--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Hatch
         run: |
           python -m pip install --upgrade pip
-          pip install hatch
+          pip install hatch "virtualenv<20.29"
 
       - name: Set up Hatch Environment
         run: |


### PR DESCRIPTION
This pull request makes a small update to the CI workflow for Python projects. The change ensures that a specific version of `virtualenv` is installed when setting up the environment, likely to address compatibility issues with newer versions.

* Updated the installation step in `.github/workflows/ci.python.yml` to pin `virtualenv` to a version below 20.29 when installing `hatch`.