### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.python.yml
+++ b/.github/workflows/ci.python.yml
@@ -15,6 +15,8 @@ defaults:
 
 jobs:
   pyright:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/TypeChat/security/code-scanning/6](https://github.com/microsoft/TypeChat/security/code-scanning/6)

In general, the fix is to explicitly define a `permissions:` block either at the workflow root (top-level, applying to all jobs) or at the job level (per job). For this workflow there is a single job `pyright`, so adding `permissions:` at the job level is sufficient and clearly scoped. Since the job only needs to read the repository contents and does not intentionally write to code, issues, or PRs, we can safely restrict the token to `contents: read`. If later it turns out that `jakebailey/pyright-action` or other steps require additional scopes (e.g., `checks: write` or `pull-requests: write`), those can be added explicitly.

The single best minimal change, without altering existing functionality, is to add a `permissions:` section under `jobs.pyright` (aligned with `strategy:` and `runs-on:`). We’ll set:

```yaml
permissions:
  contents: read
```

This ensures the workflow has an explicitly read-only token for repository contents, documenting intent and preventing accidental broad write access if repo/org defaults are permissive. No additional imports or external definitions are needed, as this is purely a YAML configuration change in `.github/workflows/ci.python.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
