### PR TITLE
chore(dependabot): add npm/pip ecosystems and group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,61 @@
 
 version: 2
 updates:
+  # npm — typescript library + examples + docs site.
+  # All security alerts in this repo to date have been against
+  # typescript/package-lock.json, which previously had no ecosystem entry
+  # here, so Dependabot never opened any update PRs for them.
+  - package-ecosystem: "npm"
+    directories:
+      - "/typescript"
+      - "/typescript/examples/*"
+      - "/site"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    groups:
+      npm-production:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      npm-development:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    groups:
+      pip-all:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      pip-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      devcontainers:
+        patterns: ["*"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
+# Dependabot configuration for microsoft/TypeChat.
+#
+# Per ecosystem: routine minor/patch updates are grouped into a single
+# weekly PR; security updates ship as their own grouped PR; major-version
+# bumps fall through ungrouped (one PR per package) for breaking-change
+# review.
+#
+# Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
+    # Group routine minor/patch bumps; security updates grouped separately
+    # so they can be prioritised. Major-version bumps fall through as
+    # one-PR-per-package so they can be reviewed for breaking changes.
     groups:
       npm-production:
         dependency-type: "production"
@@ -30,6 +33,7 @@ updates:
       npm-security:
         applies-to: security-updates
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "pip"
     directory: "/python"
@@ -45,6 +49,7 @@ updates:
       pip-security:
         applies-to: security-updates
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "devcontainers"
     directory: "/"
@@ -53,6 +58,7 @@ updates:
     groups:
       devcontainers:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -61,6 +67,8 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Problem

The existing `.github/dependabot.yml` only declared the `devcontainers` and `github-actions` ecosystems. All 9 currently-open security alerts in this repo target `typescript/package-lock.json` (`tar`, `qs`, `minimatch`, `@tootallnate/once`) — a manifest under an ecosystem Dependabot wasn't watching — so **no update PRs have ever been opened for any of them**. The Python tree (`/python/pyproject.toml`) is similarly uncovered.

## Change

* Add `npm` coverage for `/typescript`, `/typescript/examples/*`, and `/site`
* Add `pip` coverage for `/python`
* Add grouping rules across all ecosystems so multiple updates in a given run collapse into a single PR. Routine version updates and security-advisory-triggered updates are grouped **separately** (via `applies-to: security-updates`) so security PRs can be prioritised on their own.
* Major-version bumps continue to open one PR per package so reviewers can evaluate them individually.

## Expected outcome

After merge, the next Dependabot run (weekly Monday) should open at most one grouped npm-security PR covering the existing 9 alerts.