### PR TITLE
ci(dependabot): switch to security-only mode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,23 @@
 # but NOT routine weekly version-update PRs. Setting
 # open-pull-requests-limit: 0 on each ecosystem block disables version
 # updates while keeping the ecosystem registered so security-update PRs
-# can still be opened automatically when an alert fires.
+# can still be opened automatically when an alert fires. (Security
+# updates have a separate, fixed limit of 10 that is unaffected by
+# open-pull-requests-limit.)
 #
 # Routine non-security upgrades are handled out-of-band (manually or by
 # a separate workflow); this file's role is to keep the security pipe
 # unblocked without flooding the repo with churn.
+#
+# Note: devcontainers is intentionally absent -- Dependabot does not
+# support security updates for that ecosystem (only version updates),
+# so a security-only config has nothing to declare for it.
+#
+# Repo-level prerequisites (Settings > Code security):
+#   - Dependency graph: enabled
+#   - Dependabot alerts: enabled
+#   - Dependabot security updates: enabled
+#   - Grouped security updates: enabled
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -26,6 +38,12 @@ updates:
     open-pull-requests-limit: 0
     labels:
       - "dependencies"
+    # Group SemVer minor/patch security alerts so multiple simultaneous
+    # advisories in this ecosystem bundle into a single PR. SemVer-major
+    # security bumps fall through to Dependabot's normal ungrouped
+    # behavior so they can be reviewed individually for breaking changes
+    # (independent of advisory severity — this is purely a SemVer-level
+    # filter).
     groups:
       npm-security:
         applies-to: security-updates
@@ -42,17 +60,6 @@ updates:
       - "dependencies"
     groups:
       pip-security:
-        applies-to: security-updates
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
-
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 0
-    groups:
-      devcontainers-security:
         applies-to: security-updates
         patterns: ["*"]
         update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,20 @@
 # Dependabot configuration for microsoft/TypeChat.
 #
-# Per ecosystem: routine minor/patch updates are grouped into a single
-# weekly PR; security updates ship as their own grouped PR; major-version
-# bumps fall through ungrouped (one PR per package) for breaking-change
-# review.
+# Security-only mode: we want Dependabot alerts (security updates) to flow,
+# but NOT routine weekly version-update PRs. Setting
+# open-pull-requests-limit: 0 on each ecosystem block disables version
+# updates while keeping the ecosystem registered so security-update PRs
+# can still be opened automatically when an alert fires.
+#
+# Routine non-security upgrades are handled out-of-band (manually or by
+# a separate workflow); this file's role is to keep the security pipe
+# unblocked without flooding the repo with churn.
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
   # npm — typescript library + examples + docs site.
-  # All security alerts in this repo to date have been against
-  # typescript/package-lock.json, which previously had no ecosystem entry
-  # here, so Dependabot never opened any update PRs for them.
   - package-ecosystem: "npm"
     directories:
       - "/typescript"
@@ -21,18 +23,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
-    # Group routine minor/patch bumps; security updates grouped separately
-    # so they can be prioritised. Major-version bumps fall through as
-    # one-PR-per-package so they can be reviewed for breaking changes.
     groups:
-      npm-production:
-        dependency-type: "production"
-        update-types: ["minor", "patch"]
-      npm-development:
-        dependency-type: "development"
-        update-types: ["minor", "patch"]
       npm-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -43,12 +37,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
-      pip-all:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
       pip-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -58,19 +50,14 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    groups:
-      devcontainers:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     groups:
-      github-actions:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,15 @@
 # Dependabot configuration for microsoft/TypeChat.
 #
-# Security-only mode: we want Dependabot alerts (security updates) to flow,
-# but NOT routine weekly version-update PRs. Setting
-# open-pull-requests-limit: 0 on each ecosystem block disables version
-# updates while keeping the ecosystem registered so security-update PRs
-# can still be opened automatically when an alert fires.
+# Single-PR-per-ecosystem mode: every routine version bump (major, minor,
+# patch) is bundled into ONE grouped PR per ecosystem per weekly run.
+# Security updates ship as their own grouped PR so they aren't buried
+# under routine churn.
 #
-# Routine non-security upgrades are handled out-of-band (manually or by
-# a separate workflow); this file's role is to keep the security pipe
-# unblocked without flooding the repo with churn.
+# Tradeoff: one large PR is easier to review at a glance than many small
+# ones, but if it fails CI the cause is harder to bisect because the
+# compounded breaking changes (e.g. dotenv 16->17 + sqlite3 5->6) all
+# land at once. If a routine PR keeps failing, drop the offending
+# package(s) from the PR's commit list and let it land without them.
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -23,10 +24,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
+      npm-all:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
       npm-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -37,10 +40,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
+      pip-all:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
       pip-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -50,14 +55,19 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    groups:
+      devcontainers-all:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
     groups:
+      github-actions-all:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,14 @@
 # Dependabot configuration for microsoft/TypeChat.
 #
-# Single-PR-per-ecosystem mode: every routine version bump (major, minor,
-# patch) is bundled into ONE grouped PR per ecosystem per weekly run.
-# Security updates ship as their own grouped PR so they aren't buried
-# under routine churn.
+# Security-only mode: we want Dependabot alerts (security updates) to flow,
+# but NOT routine weekly version-update PRs. Setting
+# open-pull-requests-limit: 0 on each ecosystem block disables version
+# updates while keeping the ecosystem registered so security-update PRs
+# can still be opened automatically when an alert fires.
 #
-# Tradeoff: one large PR is easier to review at a glance than many small
-# ones, but if it fails CI the cause is harder to bisect because the
-# compounded breaking changes (e.g. dotenv 16->17 + sqlite3 5->6) all
-# land at once. If a routine PR keeps failing, drop the offending
-# package(s) from the PR's commit list and let it land without them.
+# Routine non-security upgrades are handled out-of-band (manually or by
+# a separate workflow); this file's role is to keep the security pipe
+# unblocked without flooding the repo with churn.
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -24,12 +23,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
-      npm-all:
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
       npm-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -40,12 +37,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
-      pip-all:
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
       pip-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -55,19 +50,14 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    groups:
-      devcontainers-all:
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     groups:
-      github-actions-all:
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 0
+    groups:
+      devcontainers-security:
+        applies-to: security-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

The first scheduled Dependabot run after enabling grouping produced 19 PRs (#340-#358). Only #340 (npm-development group) was grouped; the rest were ungrouped majors -- `dotenv` 16->17 alone produced 12 PRs because it's a top-level dep in every example's `package.json`. We want **zero routine version-update PRs** — only security-update PRs.

## What this does

Sets `open-pull-requests-limit: 0` on every ecosystem block. Per [GitHub docs](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit) this disables routine version-update PRs while keeping the ecosystem registered so security-update PRs still flow when alerts fire. The `applies-to: security-updates` grouping rules are preserved.

## Followup

The 19 noisy PRs (#340-#358) were already closed. The `fix-dependabot-alerts` workflow (#339) handles automated security remediation; routine version updates are not auto-PR'd by this config.
