### PR TITLE
ci(security): use default GITHUB_TOKEN for git push, not App token

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -162,7 +162,17 @@ jobs:
       - name: Create pull request
         if: ${{ steps.fix.outputs.changes == 'true' && steps.build.outputs.build_ok == 'true' }}
         env:
+          # GH_TOKEN is the App token — used by the ``gh`` CLI for
+          # ``gh pr create`` / labelling / closing superseded PRs so the
+          # PR appears under the bot's identity.
           GH_TOKEN: ${{ steps.app-token-pr.outputs.token }}
+          # GIT_PUSH_TOKEN is the workflow's default GITHUB_TOKEN, scoped
+          # via the workflow-level ``permissions: contents: write`` block.
+          # We use it only at the very end, after all untrusted ``npm``
+          # scripts have finished running, to avoid persisting any push
+          # credential in .git/config (where dependency build scripts
+          # could read it).
+          GIT_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="automated/fix-dependabot-alerts-$(date +%Y%m%d)-${{ github.run_number }}"
           git config user.name "github-actions[bot]"
@@ -188,10 +198,12 @@ jobs:
           Unfixable: ${{ steps.fix.outputs.unfixable_count }} package(s)
 
           Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          # Push using the App token explicitly — we disabled
-          # ``persist-credentials`` on checkout, so .git/config has no
-          # creds to fall back on.
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # Push using the workflow's default GITHUB_TOKEN (scoped to
+          # contents:write at the workflow level). Configured here, not
+          # via actions/checkout's ``persist-credentials``, so the token
+          # isn't reachable from the npm install / build / test phase
+          # earlier in the job.
+          git remote set-url origin "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH"
 
           APPLIED="${{ steps.fix.outputs.applied_packages }}"


### PR DESCRIPTION
## Problem

The `fix-dependabot-alerts` scheduled run is failing at `git push` with:

```
remote: Permission to microsoft/TypeChat.git denied to typeagent-bot[bot].
fatal: ... error: 403
```

Root cause confirmed via a diagnostic step on a temp branch:
```
=== Token permissions on microsoft/TypeChat ===
{"admin":false,"maintain":false,"pull":false,"push":false,"triage":false}
```

The workflow was using the GitHub App token for `git push`, which requires `Contents: write` at the App installation level. That's a permission the App didn't have (and shouldn't need to have — it has no business reading repo content for any other reason).

## Fix

Match the `microsoft/TypeAgent` workflow pattern: keep `persist-credentials: false` on `actions/checkout` (so the token isn't reachable from untrusted `npm` install/build/test phases), but at the very end of the job — after all untrusted code has run — re-inject the workflow's own `GITHUB_TOKEN`, already scoped to `contents: write` via the workflow-level `permissions:` block, for the `git push`.

The App token is now used only where it must be:
- `gh api dependabot/alerts` (the default `GITHUB_TOKEN` can't reach this endpoint)
- `gh pr create` / labelling / closing superseded PRs (so the PR identity is the bot, not `github-actions`)

## Verification

Manually triggered a `workflow_dispatch` run against a temp branch carrying this same patch — it passed `git push` and opened #360 with the legitimate `minimatch` patch. Logs: https://github.com/microsoft/TypeChat/actions/runs/26842937700

## Cleanup follow-ups

- Temp diag branch `dev/talzacc/diag-app-token` will be deleted after this lands.
- #360 (auto-created by the temp run) is a real Dependabot remediation and should be reviewed/merged on its own merits.