### PR TITLE
docs: add community health files and README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Future features will be listed here
+
+### Changed
+- Ongoing updates
+
+### Fixed
+- Bug fixes
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thank you for your interest in contributing! We welcome contributions of all kinds.
+
+## How to Contribute
+
+### Reporting Bugs
+- Check existing [issues](../../issues) to avoid duplicates
+- Open a new issue with a clear title, description, and steps to reproduce
+
+### Suggesting Features
+- Open an issue with the `enhancement` label
+
+### Submitting Code
+
+1. **Fork** this repository
+2. **Create a branch**: `git checkout -b feature/your-feature`
+3. **Make your changes** and commit: `git commit -m "feat: description"`
+4. **Push** and open a **Pull Request**
+
+## Guidelines
+
+- Follow existing code style and conventions
+- Keep PRs focused on a single concern
+- Update documentation when changing behavior
+- Be respectful — see [Code of Conduct](CODE_OF_CONDUCT.md)
+
+---
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Add Community Health Files

This PR adds community health files to `TypeChat`:

- `CONTRIBUTING.md`
- `CHANGELOG.md`
- `README.md` — Contributing section + profile link

**CONTRIBUTING.md** — guidelines for bug reports, feature requests, and pull requests.
**CHANGELOG.md** — Keep a Changelog format template.