### PR TITLE
Reject unsafe @func names in program validator and interpreter

### DIFF
--- a/typescript/src/ts/program.ts
+++ b/typescript/src/ts/program.ts
@@ -69,10 +69,11 @@ export type ResultReference = {
 };
 
 /**
- * Determines whether a function name is safe to use as an `@func` value. The name must be a strict
- * JS identifier and must not be a member of `Object.prototype` (e.g. `constructor`, `__proto__`,
- * `toString`, `valueOf`, `hasOwnProperty`), which could otherwise be used to escape the intended
- * API surface during code generation or dispatch.
+ * Determines whether a function name is safe to use as an `@func` value. The name must be a plain
+ * ASCII identifier — a letter, underscore, or `$`, followed by letters, digits, underscores, or `$`
+ * — and must not be a member of `Object.prototype` (e.g. `constructor`, `__proto__`, `toString`,
+ * `valueOf`, `hasOwnProperty`), which could otherwise be used to escape the intended API surface
+ * during code generation or dispatch.
  */
 function isValidFunctionName(name: unknown): name is string {
     return typeof name === "string" &&
@@ -179,13 +180,15 @@ export async function evaluateJsonProgram(program: Program, onCall: (func: strin
         }
         else if (obj.hasOwnProperty("@func")) {
             const func = obj["@func"];
-            const args = obj.hasOwnProperty("@args") ? obj["@args"] : [];
+            const hasArgs = obj.hasOwnProperty("@args");
+            const args = hasArgs ? obj["@args"] : [];
             if (!isValidFunctionName(func)) {
                 throw new Error(`Invalid function name: ${JSON.stringify(func)}`);
             }
-            if (Array.isArray(args)) {
-                return await onCall(func, await evaluateArray(args));
+            if (!Array.isArray(args) || Object.keys(obj).length !== (hasArgs ? 2 : 1)) {
+                throw new Error(`Invalid function call: ${JSON.stringify(obj)}`);
             }
+            return await onCall(func, await evaluateArray(args));
         }
         else if (Array.isArray(obj)) {
             return evaluateArray(obj);

--- a/typescript/src/ts/program.ts
+++ b/typescript/src/ts/program.ts
@@ -69,6 +69,18 @@ export type ResultReference = {
 };
 
 /**
+ * Determines whether a function name is safe to use as an `@func` value. The name must be a strict
+ * JS identifier and must not be a member of `Object.prototype` (e.g. `constructor`, `__proto__`,
+ * `toString`, `valueOf`, `hasOwnProperty`), which could otherwise be used to escape the intended
+ * API surface during code generation or dispatch.
+ */
+function isValidFunctionName(name: unknown): name is string {
+    return typeof name === "string" &&
+        /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(name) &&
+        !Object.prototype.hasOwnProperty.call(Object.prototype, name);
+}
+
+/**
  * Transforms a JSON program object into an equivalent TypeScript module suitable for type checking.
  * The generated module takes the form:
  * 
@@ -116,7 +128,7 @@ export function createModuleTextFromProgram(jsonObject: object): Result<string> 
             const func = obj["@func"];
             const hasArgs = obj.hasOwnProperty("@args");
             const args = hasArgs ? obj["@args"] : [];
-            if (typeof func === "string" && (Array.isArray(args)) && Object.keys(obj).length === (hasArgs ? 2 : 1)) {
+            if (isValidFunctionName(func) && (Array.isArray(args)) && Object.keys(obj).length === (hasArgs ? 2 : 1)) {
                 return `api.${func}(${arrayToString(args)})`;
             }
         }
@@ -168,7 +180,10 @@ export async function evaluateJsonProgram(program: Program, onCall: (func: strin
         else if (obj.hasOwnProperty("@func")) {
             const func = obj["@func"];
             const args = obj.hasOwnProperty("@args") ? obj["@args"] : [];
-            if (typeof func === "string" && Array.isArray(args)) {
+            if (!isValidFunctionName(func)) {
+                throw new Error(`Invalid function name: ${JSON.stringify(func)}`);
+            }
+            if (Array.isArray(args)) {
                 return await onCall(func, await evaluateArray(args));
             }
         }

--- a/typescript/test/program.test.ts
+++ b/typescript/test/program.test.ts
@@ -104,3 +104,80 @@ describe("createModuleTextFromProgram result references", () => {
         assert.equal(result.success, false);
     });
 });
+
+// ---------------------------------------------------------------------------
+// @func name validation (source injection / unchecked dispatch)
+// ---------------------------------------------------------------------------
+
+describe("@func name validation", () => {
+    const maliciousProgram: Program = {
+    "@steps": [
+        { "@func": "play('x'); /*", "@args": [] },
+        { "@func": "deleteEverything", "@args": ["rm", "-rf", 0] },
+        { "@func": "*/ api.play", "@args": ["x"] },
+    ],
+    };
+
+    it("createModuleTextFromProgram rejects a comment-injection @func value", () => {
+    const result = createModuleTextFromProgram(maliciousProgram);
+    assert.equal(result.success, false);
+    });
+
+    it("createModuleTextFromProgram accepts a normal valid program", () => {
+    const result = createModuleTextFromProgram({
+        "@steps": [
+            { "@func": "first", "@args": [] },
+            { "@func": "second", "@args": [{ "@ref": 0 }] },
+        ],
+    });
+    assert.equal(result.success, true);
+    assert.match((result as { data: string }).data, /api\.first\(\)/);
+    assert.match((result as { data: string }).data, /api\.second\(step1\)/);
+    });
+
+    it("evaluateJsonProgram throws instead of dispatching a comment-injection @func value", async () => {
+    const calls: Array<{ func: string; args: unknown[] }> = [];
+    await assert.rejects(
+        evaluateJsonProgram(maliciousProgram, async (func, args) => {
+            calls.push({ func, args });
+            return undefined;
+        }),
+        /Invalid function name/
+    );
+    assert.equal(calls.length, 0, "no function should have been dispatched");
+    });
+
+    for (const badName of ["constructor", "__proto__", "toString", "valueOf", "hasOwnProperty"]) {
+    it(`evaluateJsonProgram throws instead of dispatching prototype member "${badName}"`, async () => {
+        const program: Program = { "@steps": [{ "@func": badName, "@args": [] }] };
+        let dispatched = false;
+        await assert.rejects(
+            evaluateJsonProgram(program, async (func, args) => {
+                dispatched = true;
+                return undefined;
+            }),
+            /Invalid function name/
+        );
+        assert.equal(dispatched, false);
+    });
+    }
+
+    it("evaluateJsonProgram dispatches a normal valid program correctly", async () => {
+    const calls: Array<{ func: string; args: unknown[] }> = [];
+    const result = await evaluateJsonProgram(
+        {
+            "@steps": [
+                { "@func": "first", "@args": [] },
+                { "@func": "second", "@args": [{ "@ref": 0 }] },
+            ],
+        },
+        async (func, args) => {
+            calls.push({ func, args });
+            return `${func}-result`;
+        }
+    );
+    assert.deepEqual(calls[0], { func: "first", args: [] });
+    assert.deepEqual(calls[1], { func: "second", args: ["first-result"] });
+    assert.equal(result, "second-result");
+    });
+});

--- a/typescript/test/program.test.ts
+++ b/typescript/test/program.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { evaluateJsonProgram, createModuleTextFromProgram, Program } from "../dist/ts/index.js";
+import { evaluateJsonProgram, createModuleTextFromProgram, Program, FunctionCall } from "../dist/ts/index.js";
 
 // ---------------------------------------------------------------------------
 // evaluateJsonProgram result-reference bounds checking
@@ -111,73 +111,125 @@ describe("createModuleTextFromProgram result references", () => {
 
 describe("@func name validation", () => {
     const maliciousProgram: Program = {
-    "@steps": [
-        { "@func": "play('x'); /*", "@args": [] },
-        { "@func": "deleteEverything", "@args": ["rm", "-rf", 0] },
-        { "@func": "*/ api.play", "@args": ["x"] },
-    ],
+        "@steps": [
+            { "@func": "play('x'); /*", "@args": [] },
+            { "@func": "deleteEverything", "@args": ["rm", "-rf", 0] },
+            { "@func": "*/ api.play", "@args": ["x"] },
+        ],
     };
 
     it("createModuleTextFromProgram rejects a comment-injection @func value", () => {
-    const result = createModuleTextFromProgram(maliciousProgram);
-    assert.equal(result.success, false);
+        const result = createModuleTextFromProgram(maliciousProgram);
+        assert.equal(result.success, false);
     });
 
     it("createModuleTextFromProgram accepts a normal valid program", () => {
-    const result = createModuleTextFromProgram({
-        "@steps": [
-            { "@func": "first", "@args": [] },
-            { "@func": "second", "@args": [{ "@ref": 0 }] },
-        ],
-    });
-    assert.equal(result.success, true);
-    assert.match((result as { data: string }).data, /api\.first\(\)/);
-    assert.match((result as { data: string }).data, /api\.second\(step1\)/);
+        const result = createModuleTextFromProgram({
+            "@steps": [
+                { "@func": "first", "@args": [] },
+                { "@func": "second", "@args": [{ "@ref": 0 }] },
+            ],
+        });
+        assert.equal(result.success, true);
+        assert.match((result as { data: string }).data, /api\.first\(\)/);
+        assert.match((result as { data: string }).data, /api\.second\(step1\)/);
     });
 
     it("evaluateJsonProgram throws instead of dispatching a comment-injection @func value", async () => {
-    const calls: Array<{ func: string; args: unknown[] }> = [];
-    await assert.rejects(
-        evaluateJsonProgram(maliciousProgram, async (func, args) => {
-            calls.push({ func, args });
-            return undefined;
-        }),
-        /Invalid function name/
-    );
-    assert.equal(calls.length, 0, "no function should have been dispatched");
+        const calls: Array<{ func: string; args: unknown[] }> = [];
+        await assert.rejects(
+            evaluateJsonProgram(maliciousProgram, async (func, args) => {
+                calls.push({ func, args });
+                return undefined;
+            }),
+            /Invalid function name/
+        );
+        assert.equal(calls.length, 0, "no function should have been dispatched");
     });
 
     for (const badName of ["constructor", "__proto__", "toString", "valueOf", "hasOwnProperty"]) {
-    it(`evaluateJsonProgram throws instead of dispatching prototype member "${badName}"`, async () => {
-        const program: Program = { "@steps": [{ "@func": badName, "@args": [] }] };
+        it(`evaluateJsonProgram throws instead of dispatching prototype member "${badName}"`, async () => {
+            const program: Program = { "@steps": [{ "@func": badName, "@args": [] }] };
+            let dispatched = false;
+            await assert.rejects(
+                evaluateJsonProgram(program, async (func, args) => {
+                    dispatched = true;
+                    return undefined;
+                }),
+                /Invalid function name/
+            );
+            assert.equal(dispatched, false);
+        });
+    }
+
+    it("evaluateJsonProgram dispatches a normal valid program correctly", async () => {
+        const calls: Array<{ func: string; args: unknown[] }> = [];
+        const result = await evaluateJsonProgram(
+            {
+                "@steps": [
+                    { "@func": "first", "@args": [] },
+                    { "@func": "second", "@args": [{ "@ref": 0 }] },
+                ],
+            },
+            async (func, args) => {
+                calls.push({ func, args });
+                return `${func}-result`;
+            }
+        );
+        assert.deepEqual(calls[0], { func: "first", args: [] });
+        assert.deepEqual(calls[1], { func: "second", args: ["first-result"] });
+        assert.equal(result, "second-result");
+    });
+
+    it("createModuleTextFromProgram rejects a call object with a non-array @args", () => {
+        const result = createModuleTextFromProgram({
+            "@steps": [
+                { "@func": "first", "@args": "not-an-array" as unknown as [] },
+            ],
+        });
+        assert.equal(result.success, false);
+    });
+
+    it("createModuleTextFromProgram rejects a call object with extra unexpected keys", () => {
+        const result = createModuleTextFromProgram({
+            "@steps": [
+                { "@func": "first", "@args": [], "extra": true } as unknown as FunctionCall,
+            ],
+        });
+        assert.equal(result.success, false);
+    });
+
+    it("evaluateJsonProgram throws instead of dispatching a call object with a non-array @args", async () => {
+        const program = {
+            "@steps": [
+                { "@func": "first", "@args": "not-an-array" },
+            ],
+        } as unknown as Program;
         let dispatched = false;
         await assert.rejects(
             evaluateJsonProgram(program, async (func, args) => {
                 dispatched = true;
                 return undefined;
             }),
-            /Invalid function name/
+            /Invalid function call/
         );
         assert.equal(dispatched, false);
     });
-    }
 
-    it("evaluateJsonProgram dispatches a normal valid program correctly", async () => {
-    const calls: Array<{ func: string; args: unknown[] }> = [];
-    const result = await evaluateJsonProgram(
-        {
+    it("evaluateJsonProgram throws instead of dispatching a call object with extra unexpected keys", async () => {
+        const program = {
             "@steps": [
-                { "@func": "first", "@args": [] },
-                { "@func": "second", "@args": [{ "@ref": 0 }] },
+                { "@func": "first", "@args": [], "extra": true },
             ],
-        },
-        async (func, args) => {
-            calls.push({ func, args });
-            return `${func}-result`;
-        }
-    );
-    assert.deepEqual(calls[0], { func: "first", args: [] });
-    assert.deepEqual(calls[1], { func: "second", args: ["first-result"] });
-    assert.equal(result, "second-result");
+        } as unknown as Program;
+        let dispatched = false;
+        await assert.rejects(
+            evaluateJsonProgram(program, async (func, args) => {
+                dispatched = true;
+                return undefined;
+            }),
+            /Invalid function call/
+        );
+        assert.equal(dispatched, false);
     });
 });


### PR DESCRIPTION
## Vulnerability

`createModuleTextFromProgram` concatenated the model-supplied `@func` name raw into generated TypeScript (`api.${func}(...)`) with no identifier check. A `@func` value containing comment tokens (`/* ... */`) could comment out later generated steps, so the type-checker-based validator (which is the sole validation gate for programs) would report success even though a later step called an undeclared function.

Separately, `evaluateJsonProgram` only checked `typeof func === "string"` before forwarding the name to the host's `onCall` dispatcher, so names like `constructor`, `__proto__`, `toString`, `valueOf`, `hasOwnProperty` could reach hosts that dispatch via `api[func](...)`, resolving to `Object.prototype` members the schema never declared.

## Fix

Added one shared `isValidFunctionName` predicate (strict identifier regex + rejects `Object.prototype` members) used by both:
- `createModuleTextFromProgram` — invalid `@func` names are now treated as an invalid expression, so the whole program fails validation.
- `evaluateJsonProgram` — invalid `@func` names now throw instead of being dispatched.

This guarantees the two code paths can never disagree about which programs are legal.

`@ref` bounds checking is unrelated and already fixed in #393 (already merged to `main`).

## Tests

Added `typescript/test/program.test.ts` cases:
- The comment-injection repro program fails `createModuleTextFromProgram` validation.
- `evaluateJsonProgram` throws (and never dispatches) for the comment-injection name and for `constructor`/`__proto__`/`toString`/`valueOf`/`hasOwnProperty`.
- A normal valid program still validates and dispatches correctly.

Wired `out/program.test.js` into the `test` npm script.

`npm run build` (tsc -p src, tsc -p test) passes; `node --test out/validate.test.js out/zod.test.js out/program.test.js tests/model.test.mjs` → 97/97 tests pass. Also manually verified the exact malicious repro from the report is now rejected by `createModuleTextFromProgram` and throws in `evaluateJsonProgram` rather than dispatching.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>